### PR TITLE
Remove dim and resolve the resulting problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ n_adapts = 2_000
 θ_init = randn(D)
 
 # Define metric space, Hamiltonian and sampling method
-metric = UnitEuclideanMetric(D)
+metric = DenseEuclideanMetric(D)
 h = Hamiltonian(metric, logπ, ∂logπ∂θ)
 prop = NUTS(Leapfrog(find_good_eps(h, θ_init)))
 adaptor = StanNUTSAdaptor(n_adapts, PreConditioner(metric), NesterovDualAveraging(0.8, prop.integrator.ϵ))

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ n_adapts = 2_000
 θ_init = randn(D)
 
 # Define metric space, Hamiltonian and sampling method
-metric = UnitEuclideanMetric{eltype(θ_init)}(D)
+metric = UnitEuclideanMetric(D)
 h = Hamiltonian(metric, logπ, ∂logπ∂θ)
 prop = NUTS(Leapfrog(find_good_eps(h, θ_init)))
 adaptor = StanNUTSAdaptor(n_adapts, PreConditioner(metric), NesterovDualAveraging(0.8, prop.integrator.ϵ))

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ n_adapts = 2_000
 θ_init = randn(D)
 
 # Define metric space, Hamiltonian and sampling method
-metric = DenseEuclideanMetric(θ_init)
+metric = UnitEuclideanMetric{eltype(θ_init)}(D)
 h = Hamiltonian(metric, logπ, ∂logπ∂θ)
 prop = NUTS(Leapfrog(find_good_eps(h, θ_init)))
 adaptor = StanNUTSAdaptor(n_adapts, PreConditioner(metric), NesterovDualAveraging(0.8, prop.integrator.ϵ))

--- a/src/AdvancedHMC.jl
+++ b/src/AdvancedHMC.jl
@@ -5,7 +5,7 @@ const DEBUG = Bool(parse(Int, get(ENV, "DEBUG_AHMC", "0")))
 using Statistics: mean, var, middle
 using LinearAlgebra: Symmetric, UpperTriangular, mul!, ldiv!, dot, I, diag, cholesky
 using LazyArrays: BroadcastArray
-using Random: GLOBAL_RNG, AbstractRNG, randn!
+using Random: GLOBAL_RNG, AbstractRNG
 
 # Notations
 # d - dimension of sampling sapce

--- a/src/AdvancedHMC.jl
+++ b/src/AdvancedHMC.jl
@@ -5,7 +5,7 @@ const DEBUG = Bool(parse(Int, get(ENV, "DEBUG_AHMC", "0")))
 using Statistics: mean, var, middle
 using LinearAlgebra: Symmetric, UpperTriangular, mul!, ldiv!, dot, I, diag, cholesky
 using LazyArrays: BroadcastArray
-using Random: GLOBAL_RNG, AbstractRNG
+using Random: GLOBAL_RNG, AbstractRNG, randn!
 
 # Notations
 # d - dimension of sampling sapce

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -37,12 +37,14 @@ function rand_momentum(rng::AbstractRNG, h::Hamiltonian{<:UnitEuclideanMetric})
     return randn(rng, h.metric.dim)
 end
 function rand_momentum(rng::AbstractRNG, h::Hamiltonian{<:DiagEuclideanMetric})
-    h.metric._temp .= randn.(Ref(rng))
-    return h.metric._temp ./ h.metric.sqrtM⁻¹
+    r = randn(rng, h.metric.dim)
+    r ./= h.metric.sqrtM⁻¹
+    return r
 end
 function rand_momentum(rng::AbstractRNG, h::Hamiltonian{<:DenseEuclideanMetric})
-    h.metric._temp .= randn.(Ref(rng))
-    return h.metric.cholM⁻¹ \ h.metric._temp
+    r = randn(rng, h.metric.dim)
+    ldiv!(h.metric.cholM⁻¹, r)
+    return r
 end
 
 rand_momentum(h::Hamiltonian) = rand_momentum(GLOBAL_RNG, h)

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -1,66 +1,46 @@
 # TODO: add a type for kinetic energy
 
-struct Hamiltonian{T<:Real,M<:AbstractMetric{T},F1,F2}
-    metric      ::  M
-    logπ        ::  F1
-    ∂logπ∂θ     ::  F2
+struct Hamiltonian{M<:AbstractMetric, Tlogπ, T∂logπ∂θ}
+    metric::M
+    logπ::Tlogπ
+    ∂logπ∂θ::T∂logπ∂θ
 end
 
 # Create a `Hamiltonian` with a new `M⁻¹`
-function (h::Hamiltonian)(M⁻¹)
-    return Hamiltonian(h.metric(M⁻¹), h.logπ, h.∂logπ∂θ)
-end
+(h::Hamiltonian)(M⁻¹) = Hamiltonian(h.metric(M⁻¹), h.logπ, h.∂logπ∂θ)
 
-function ∂H∂θ(h::Hamiltonian, θ::AV)::AV where {T<:Real,AV<:AbstractVector{T}}
-    return -h.∂logπ∂θ(θ)
-end
+∂H∂θ(h::Hamiltonian, θ::AbstractVector) = -h.∂logπ∂θ(θ)
 
-function ∂H∂r(h::Hamiltonian{T,UnitEuclideanMetric{T},F1,F2}, r::A) where {T<:Real,F1,F2,A<:AbstractVector{T}}
-    return copy(r)
-end
+∂H∂r(h::Hamiltonian{<:UnitEuclideanMetric}, r::AbstractVector) = copy(r)
+∂H∂r(h::Hamiltonian{<:DiagEuclideanMetric}, r::AbstractVector) = h.metric.M⁻¹ .* r
+∂H∂r(h::Hamiltonian{<:DenseEuclideanMetric}, r::AbstractVector) = h.metric.M⁻¹ * r
 
-function ∂H∂r(h::Hamiltonian{T,DiagEuclideanMetric{T,A},F1,F2}, r::A) where {T<:Real,A<:AbstractVector{T},F1,F2}
-    return h.metric.M⁻¹ .* r
-end
-
-function ∂H∂r(h::Hamiltonian{T,DenseEuclideanMetric{T,AV,AM},F1,F2}, r::AV) where {T<:Real,AM<:AbstractMatrix{T},F1,F2,AV<:AbstractVector{T}}
-    return h.metric.M⁻¹ * r
-end
-
-function hamiltonian_energy(h::Hamiltonian, θ::AbstractVector{T}, r::AbstractVector{T}) where {T<:Real}
+function hamiltonian_energy(h::Hamiltonian, θ::AbstractVector, r::AbstractVector)
     return kinetic_energy(h, r, θ) + potential_energy(h, θ)
 end
 
-function potential_energy(h::Hamiltonian, θ::AbstractVector{T}) where {T<:Real}
-    return -h.logπ(θ)
-end
+potential_energy(h::Hamiltonian, θ::AbstractVector) = -h.logπ(θ)
 
 # Kinetic energy
 # NOTE: the general form of K depends on both θ and r
-function kinetic_energy(h::Hamiltonian{T,UnitEuclideanMetric{T},F1,F2}, r::A, ::A) where {T<:Real,F1,F2,A<:AbstractVector{T}}
-    return sum(abs2, r) / 2
-end
-
-function kinetic_energy(h::Hamiltonian{T,DiagEuclideanMetric{T,A},F1,F2}, r::A, ::A) where {T<:Real,A<:AbstractVector{T},F1,F2}
+kinetic_energy(h::Hamiltonian{<:UnitEuclideanMetric}, r, θ) = sum(abs2, r) / 2
+function kinetic_energy(h::Hamiltonian{<:DiagEuclideanMetric}, r, θ)
     return sum(abs2(r[i]) * h.metric.M⁻¹[i] for i in 1:length(r)) / 2
 end
-
-function kinetic_energy(h::Hamiltonian{T,DenseEuclideanMetric{T,AV,AM},F1,F2}, r::AV, ::AV) where {T<:Real,AM<:AbstractMatrix{T},F1,F2,AV<:AbstractVector{T}}
+function kinetic_energy(h::Hamiltonian{<:DenseEuclideanMetric}, r, θ)
     mul!(h.metric._temp, h.metric.M⁻¹, r)
     return dot(r, h.metric._temp) / 2
 end
 
 # Momentum sampler
-function rand_momentum(rng::AbstractRNG, h::Hamiltonian{T,UnitEuclideanMetric{T},F1,F2}) where {T<:Real,F1,F2,A<:AbstractVector{T}}
+function rand_momentum(rng::AbstractRNG, h::Hamiltonian{<:UnitEuclideanMetric})
     return randn(rng, h.metric.dim)
 end
-
-function rand_momentum(rng::AbstractRNG, h::Hamiltonian{T,DiagEuclideanMetric{T,A},F1,F2}) where {T<:Real,A<:AbstractVector{T},F1,F2}
+function rand_momentum(rng::AbstractRNG, h::Hamiltonian{<:DiagEuclideanMetric})
     h.metric._temp .= randn.(Ref(rng))
     return h.metric._temp ./ h.metric.sqrtM⁻¹
 end
-
-function rand_momentum(rng::AbstractRNG, h::Hamiltonian{T,DenseEuclideanMetric{T,AV,AM},F1,F2}) where {T<:Real,AM<:AbstractMatrix{T},F1,F2,AV<:AbstractVector{T}}
+function rand_momentum(rng::AbstractRNG, h::Hamiltonian{<:DenseEuclideanMetric})
     h.metric._temp .= randn.(Ref(rng))
     return h.metric.cholM⁻¹ \ h.metric._temp
 end

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -31,6 +31,7 @@ end
 function DiagEuclideanMetric(M⁻¹::AbstractVector{T}) where {T<:Real}
     return DiagEuclideanMetric(M⁻¹, sqrt.(M⁻¹), Vector{T}(undef, size(M⁻¹, 1)))
 end
+DiagEuclideanMetric(D::Int) = DiagEuclideanMetric(ones(Float64, D))
 
 # Create a `DiagEuclideanMetric` with a new `M⁻¹`
 (dem::DiagEuclideanMetric)(M⁻¹::AbstractVector{<:Real}) = DiagEuclideanMetric(M⁻¹)
@@ -59,6 +60,7 @@ function DenseEuclideanMetric(M⁻¹::AbstractMatrix{T}) where {T<:Real}
     _temp = Vector{T}(undef, size(M⁻¹, 1))
     return DenseEuclideanMetric(M⁻¹, cholesky(Symmetric(M⁻¹)).U, _temp)
 end
+DenseEuclideanMetric(D::Int) = DenseEuclideanMetric(Matrix{Float64}(I, D, D))
 
 # Create a `DenseEuclideanMetric` with a new `M⁻¹`
 (dem::DenseEuclideanMetric)(M⁻¹::AbstractMatrix{<:Real}) = DenseEuclideanMetric(M⁻¹)

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -1,11 +1,11 @@
-abstract type AbstractMetric{T} end
+abstract type AbstractMetric end
 
-struct UnitEuclideanMetric{T<:Real} <: AbstractMetric{T}
+struct UnitEuclideanMetric <: AbstractMetric
     dim::Int
 end
 
 # Create a `UnitEuclideanMetric`; required for an unified interface
-(ue::UnitEuclideanMetric{T})(::Nothing) where {T<:Real} = UnitEuclideanMetric{T}(ue.dim)
+(ue::UnitEuclideanMetric)(::Nothing) = UnitEuclideanMetric(ue.dim)
 
 function _string_diag(d, n_chars::Int=32) :: String
     s_diag = string(d)
@@ -15,11 +15,11 @@ function _string_diag(d, n_chars::Int=32) :: String
     return s_diag[1:min(n_diag_chars,end)] * (l > n_diag_chars ? s_dots : "")
 end
 
-function Base.show(io::IO, uem::UnitEuclideanMetric{T}) where {T<:Real}
-    return print(io, _string_diag(ones(T, uem.dim)))
+function Base.show(io::IO, uem::UnitEuclideanMetric)
+    return print(io, _string_diag(ones(uem.dim)))
 end
 
-struct DiagEuclideanMetric{T<:Real,A<:AbstractVector{T}} <: AbstractMetric{T}
+struct DiagEuclideanMetric{A<:AbstractVector} <: AbstractMetric
     # Diagnal of the inverse of the mass matrix
     M⁻¹     ::  A
     # Sqare root of the inverse of the mass matrix
@@ -42,11 +42,11 @@ function Base.getproperty(dem::DiagEuclideanMetric, d::Symbol)
 end
 
 
-struct DenseEuclideanMetric{T<:Real,AV<:AbstractVector{T},AM<:AbstractMatrix{T}} <: AbstractMetric{T}
+struct DenseEuclideanMetric{AV<:AbstractVector, AM<:AbstractMatrix} <: AbstractMetric
     # Inverse of the mass matrix
     M⁻¹     ::  AM
     # U of the Cholesky decomposition of the mass matrix
-    cholM⁻¹ ::  UpperTriangular{T,AM}
+    cholM⁻¹ ::  UpperTriangular
     # Pre-allocation for intermediate variables
     _temp   ::  AV
 end

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -42,13 +42,17 @@ function Base.getproperty(dem::DiagEuclideanMetric, d::Symbol)
 end
 
 
-struct DenseEuclideanMetric{AV<:AbstractVector, AM<:AbstractMatrix} <: AbstractMetric
+struct DenseEuclideanMetric{
+    AV<:AbstractVector,
+    AM<:AbstractMatrix,
+    TcholM⁻¹<:UpperTriangular,
+} <: AbstractMetric
     # Inverse of the mass matrix
-    M⁻¹     ::  AM
+    M⁻¹::AM
     # U of the Cholesky decomposition of the mass matrix
-    cholM⁻¹ ::  UpperTriangular
+    cholM⁻¹::TcholM⁻¹
     # Pre-allocation for intermediate variables
-    _temp   ::  AV
+    _temp::AV
 end
 
 function DenseEuclideanMetric(M⁻¹::AbstractMatrix{T}) where {T<:Real}

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -1,8 +1,11 @@
 abstract type AbstractMetric{T} end
 
 struct UnitEuclideanMetric{T<:Real} <: AbstractMetric{T}
-    dim :: Int
+    dim::Int
 end
+
+# Create a `UnitEuclideanMetric`; required for an unified interface
+(ue::UnitEuclideanMetric{T})(::Nothing) where {T<:Real} = UnitEuclideanMetric{T}(ue.dim)
 
 function _string_diag(d, n_chars::Int=32) :: String
     s_diag = string(d)
@@ -11,19 +14,12 @@ function _string_diag(d, n_chars::Int=32) :: String
     n_diag_chars = n_chars - length(s_dots)
     return s_diag[1:min(n_diag_chars,end)] * (l > n_diag_chars ? s_dots : "")
 end
-Base.show(io::IO, uem::UnitEuclideanMetric{T}) where {T<:Real} = print(io, _string_diag(ones(T, uem.dim)))
 
-function UnitEuclideanMetric(θ::A) where {T<:Real,A<:AbstractVector{T}}
-    return UnitEuclideanMetric{T}(length(θ))
-end
-
-# Create a `UnitEuclideanMetric`; required for an unified interface
-function (ue::UnitEuclideanMetric{T})(::Nothing) where {T<:Real}
-    return UnitEuclideanMetric{T}(ue.dim)
+function Base.show(io::IO, uem::UnitEuclideanMetric{T}) where {T<:Real}
+    return print(io, _string_diag(ones(T, uem.dim)))
 end
 
 struct DiagEuclideanMetric{T<:Real,A<:AbstractVector{T}} <: AbstractMetric{T}
-    dim     :: Int
     # Diagnal of the inverse of the mass matrix
     M⁻¹     ::  A
     # Sqare root of the inverse of the mass matrix
@@ -32,29 +28,21 @@ struct DiagEuclideanMetric{T<:Real,A<:AbstractVector{T}} <: AbstractMetric{T}
     _temp   ::  A
 end
 
-Base.show(io::IO, dem::DiagEuclideanMetric) = print(io, _string_diag(dem.M⁻¹))
+function DiagEuclideanMetric(M⁻¹::AbstractVector{T}) where {T<:Real}
+    return DiagEuclideanMetric(M⁻¹, sqrt.(M⁻¹), Vector{T}(undef, size(M⁻¹, 1)))
+end
 
 # Create a `DiagEuclideanMetric` with a new `M⁻¹`
-function (dem::DiagEuclideanMetric)(M⁻¹::A) where {T<:Real,A<:AbstractVector{T}}
-    return DiagEuclideanMetric(dem.dim, M⁻¹)
+(dem::DiagEuclideanMetric)(M⁻¹::AbstractVector{<:Real}) = DiagEuclideanMetric(M⁻¹)
+
+Base.show(io::IO, dem::DiagEuclideanMetric) = print(io, _string_diag(dem.M⁻¹))
+
+function Base.getproperty(dem::DiagEuclideanMetric, d::Symbol)
+    return d === :dim ? size(getfield(dem, :M⁻¹), 1) : getfield(dem, d)
 end
 
-function DiagEuclideanMetric(θ::A) where {T<:Real,A<:AbstractVector{T}}
-    dim = length(θ)
-    return DiagEuclideanMetric(dim, ones(T, dim))
-end
-
-function DiagEuclideanMetric(θ::A, M⁻¹::A) where {T<:Real,A<:AbstractVector{T}}
-    return DiagEuclideanMetric(length(θ), M⁻¹)
-end
-
-function DiagEuclideanMetric(dim::Int, M⁻¹::V) where {T<:Real,V<:AbstractVector{T}}
-    @assert dim == length(M⁻¹)
-    return DiagEuclideanMetric(dim, M⁻¹, sqrt.(M⁻¹), zeros(T, dim))
-end
 
 struct DenseEuclideanMetric{T<:Real,AV<:AbstractVector{T},AM<:AbstractMatrix{T}} <: AbstractMetric{T}
-    dim     :: Int
     # Inverse of the mass matrix
     M⁻¹     ::  AM
     # U of the Cholesky decomposition of the mass matrix
@@ -63,23 +51,16 @@ struct DenseEuclideanMetric{T<:Real,AV<:AbstractVector{T},AM<:AbstractMatrix{T}}
     _temp   ::  AV
 end
 
-Base.show(io::IO, dem::DenseEuclideanMetric) = print(io, _string_diag(diag(dem.M⁻¹)))
+function DenseEuclideanMetric(M⁻¹::AbstractMatrix{T}) where {T<:Real}
+    _temp = Vector{T}(undef, size(M⁻¹, 1))
+    return DenseEuclideanMetric(M⁻¹, cholesky(Symmetric(M⁻¹)).U, _temp)
+end
 
 # Create a `DenseEuclideanMetric` with a new `M⁻¹`
-function (dem::DenseEuclideanMetric)(M⁻¹::A) where {T<:Real,A<:AbstractMatrix{T}}
-    return DenseEuclideanMetric(dem.dim, M⁻¹)
-end
+(dem::DenseEuclideanMetric)(M⁻¹::AbstractMatrix{<:Real}) = DenseEuclideanMetric(M⁻¹)
 
-function DenseEuclideanMetric(θ::A) where {T<:Real,A<:AbstractVector{T}}
-    dim = length(θ)
-    return DenseEuclideanMetric(dim, Matrix{T}(I, dim, dim))
-end
+Base.show(io::IO, dem::DenseEuclideanMetric) = print(io, _string_diag(diag(dem.M⁻¹)))
 
-function DenseEuclideanMetric(θ::AV, M⁻¹::AM) where {T<:Real,AV<:AbstractVector{T},AM<:AbstractMatrix{T}}
-    return DenseEuclideanMetric(length(θ), M⁻¹)
-end
-
-function DenseEuclideanMetric(dim::Int, M⁻¹::M) where {T<:Real,M<:AbstractMatrix{T}}
-    @assert dim == size(M⁻¹, 1)
-    return DenseEuclideanMetric(dim, M⁻¹, cholesky(Symmetric(M⁻¹)).U, zeros(T, dim))
+function Base.getproperty(dem::DenseEuclideanMetric, d::Symbol)
+    return d === :dim ? size(getfield(dem, :M⁻¹), 1) : getfield(dem, d)
 end

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -15,9 +15,7 @@ function _string_diag(d, n_chars::Int=32) :: String
     return s_diag[1:min(n_diag_chars,end)] * (l > n_diag_chars ? s_dots : "")
 end
 
-function Base.show(io::IO, uem::UnitEuclideanMetric)
-    return print(io, _string_diag(ones(uem.dim)))
-end
+Base.show(io::IO, uem::UnitEuclideanMetric) = print(io, _string_diag(ones(uem.dim)))
 
 struct DiagEuclideanMetric{A<:AbstractVector} <: AbstractMetric
     # Diagnal of the inverse of the mass matrix

--- a/test/hamiltonian.jl
+++ b/test/hamiltonian.jl
@@ -3,7 +3,7 @@ using Test, AdvancedHMC
 include("common.jl")
 
 θ_init = randn(D)
-h = Hamiltonian(UnitEuclideanMetric{Float64}(D), logπ, ∂logπ∂θ)
+h = Hamiltonian(UnitEuclideanMetric(D), logπ, ∂logπ∂θ)
 r_init = ones(D)
 
 @test AdvancedHMC.kinetic_energy(h, r_init, θ_init) == D / 2

--- a/test/hamiltonian.jl
+++ b/test/hamiltonian.jl
@@ -3,7 +3,7 @@ using Test, AdvancedHMC
 include("common.jl")
 
 θ_init = randn(D)
-h = Hamiltonian(UnitEuclideanMetric(θ_init), logπ, ∂logπ∂θ)
+h = Hamiltonian(UnitEuclideanMetric{Float64}(D), logπ, ∂logπ∂θ)
 r_init = ones(D)
 
 @test AdvancedHMC.kinetic_energy(h, r_init, θ_init) == D / 2

--- a/test/hmc.jl
+++ b/test/hmc.jl
@@ -1,4 +1,4 @@
-using Test, AdvancedHMC
+using Test, AdvancedHMC, LinearAlgebra
 using Statistics: mean, var, cov
 include("common.jl")
 
@@ -9,9 +9,9 @@ n_samples = 100_000
 n_adapts = 2_000
 
 @testset "HMC and NUTS" begin
-    @testset "$(typeof(metric))" for metric in [UnitEuclideanMetric(θ_init),
-                                                DiagEuclideanMetric(θ_init),
-                                                DenseEuclideanMetric(θ_init)]
+    @testset "$(typeof(metric))" for metric in [UnitEuclideanMetric{Float64}(D),
+                                                DiagEuclideanMetric(ones(D)),
+                                                DenseEuclideanMetric(Matrix{Float64}(I, D ,D))]
         h = Hamiltonian(metric, logπ, ∂logπ∂θ)
         @testset "$(typeof(prop))" for prop in [TakeLastProposal(Leapfrog(ϵ), n_steps),
                                                 NUTS(Leapfrog(find_good_eps(h, θ_init)))]

--- a/test/hmc.jl
+++ b/test/hmc.jl
@@ -11,8 +11,8 @@ n_adapts = 2_000
 @testset "HMC and NUTS" begin
     @testset "$(typeof(metric))" for metric in [
         UnitEuclideanMetric(D),
-        DiagEuclideanMetric(ones(D)),
-        DenseEuclideanMetric(Matrix{Float64}(I, D ,D)),
+        DiagEuclideanMetric(D),
+        DenseEuclideanMetric(D),
     ]
         h = Hamiltonian(metric, logπ, ∂logπ∂θ)
         @testset "$(typeof(prop))" for prop in [

--- a/test/hmc.jl
+++ b/test/hmc.jl
@@ -9,7 +9,7 @@ n_samples = 100_000
 n_adapts = 2_000
 
 @testset "HMC and NUTS" begin
-    @testset "$(typeof(metric))" for metric in [UnitEuclideanMetric{Float64}(D),
+    @testset "$(typeof(metric))" for metric in [UnitEuclideanMetric(D),
                                                 DiagEuclideanMetric(ones(D)),
                                                 DenseEuclideanMetric(Matrix{Float64}(I, D ,D))]
         h = Hamiltonian(metric, logπ, ∂logπ∂θ)

--- a/test/hmc.jl
+++ b/test/hmc.jl
@@ -9,18 +9,31 @@ n_samples = 100_000
 n_adapts = 2_000
 
 @testset "HMC and NUTS" begin
-    @testset "$(typeof(metric))" for metric in [UnitEuclideanMetric(D),
-                                                DiagEuclideanMetric(ones(D)),
-                                                DenseEuclideanMetric(Matrix{Float64}(I, D ,D))]
+    @testset "$(typeof(metric))" for metric in [
+        UnitEuclideanMetric(D),
+        DiagEuclideanMetric(ones(D)),
+        DenseEuclideanMetric(Matrix{Float64}(I, D ,D)),
+    ]
         h = Hamiltonian(metric, logπ, ∂logπ∂θ)
-        @testset "$(typeof(prop))" for prop in [TakeLastProposal(Leapfrog(ϵ), n_steps),
-                                                NUTS(Leapfrog(find_good_eps(h, θ_init)))]
+        @testset "$(typeof(prop))" for prop in [
+            TakeLastProposal(Leapfrog(ϵ), n_steps),
+            NUTS(Leapfrog(find_good_eps(h, θ_init))),
+        ]
             samples = sample(h, prop, θ_init, n_samples; verbose=false)
             @test mean(samples[n_adapts+1:end]) ≈ zeros(D) atol=RNDATOL
-            @testset "$(typeof(adaptor))" for adaptor in [PreConditioner(metric),
-                                                          NesterovDualAveraging(0.8, prop.integrator.ϵ),
-                                                          NaiveCompAdaptor(PreConditioner(metric), NesterovDualAveraging(0.8, prop.integrator.ϵ)),
-                                                          StanNUTSAdaptor(n_adapts, PreConditioner(metric), NesterovDualAveraging(0.8, prop.integrator.ϵ))]
+            @testset "$(typeof(adaptor))" for adaptor in [
+                PreConditioner(metric),
+                NesterovDualAveraging(0.8, prop.integrator.ϵ),
+                NaiveCompAdaptor(
+                    PreConditioner(metric),
+                    NesterovDualAveraging(0.8, prop.integrator.ϵ),
+                ),
+                StanNUTSAdaptor(
+                    n_adapts,
+                    PreConditioner(metric),
+                    NesterovDualAveraging(0.8, prop.integrator.ϵ),
+                ),
+            ]
                 samples = sample(h, prop, θ_init, n_samples, adaptor, n_adapts; verbose=false)
                 @test mean(samples[n_adapts+1:end]) ≈ zeros(D) atol=RNDATOL
             end

--- a/test/integrator.jl
+++ b/test/integrator.jl
@@ -5,7 +5,7 @@ include("common.jl")
 lf = Leapfrog(ϵ)
 
 θ_init = randn(D)
-h = Hamiltonian(UnitEuclideanMetric(θ_init), logπ, ∂logπ∂θ)
+h = Hamiltonian(UnitEuclideanMetric{Float64}(D), logπ, ∂logπ∂θ)
 r_init = AdvancedHMC.rand_momentum(h)
 
 n_steps = 10
@@ -46,7 +46,7 @@ using Statistics: mean
     lf = Leapfrog(ϵ)
 
     q_init = randn(D)
-    h = Hamiltonian(UnitEuclideanMetric(q_init), negU, ∂negU∂q)
+    h = Hamiltonian(UnitEuclideanMetric{Float64}(D), negU, ∂negU∂q)
     p_init = AdvancedHMC.rand_momentum(h)
 
     q, p = copy(q_init), copy(p_init)

--- a/test/integrator.jl
+++ b/test/integrator.jl
@@ -5,7 +5,7 @@ include("common.jl")
 lf = Leapfrog(ϵ)
 
 θ_init = randn(D)
-h = Hamiltonian(UnitEuclideanMetric{Float64}(D), logπ, ∂logπ∂θ)
+h = Hamiltonian(UnitEuclideanMetric(D), logπ, ∂logπ∂θ)
 r_init = AdvancedHMC.rand_momentum(h)
 
 n_steps = 10
@@ -46,7 +46,7 @@ using Statistics: mean
     lf = Leapfrog(ϵ)
 
     q_init = randn(D)
-    h = Hamiltonian(UnitEuclideanMetric{Float64}(D), negU, ∂negU∂q)
+    h = Hamiltonian(UnitEuclideanMetric(D), negU, ∂negU∂q)
     p_init = AdvancedHMC.rand_momentum(h)
 
     q, p = copy(q_init), copy(p_init)

--- a/test/proposal.jl
+++ b/test/proposal.jl
@@ -6,7 +6,7 @@ include("common.jl")
 lf = Leapfrog(ϵ)
 
 θ_init = randn(D)
-h = Hamiltonian(UnitEuclideanMetric{Float64}(D), logπ, ∂logπ∂θ)
+h = Hamiltonian(UnitEuclideanMetric(D), logπ, ∂logπ∂θ)
 prop = NUTS(Leapfrog(find_good_eps(h, θ_init)))
 r_init = AdvancedHMC.rand_momentum(h)
 

--- a/test/proposal.jl
+++ b/test/proposal.jl
@@ -6,7 +6,7 @@ include("common.jl")
 lf = Leapfrog(ϵ)
 
 θ_init = randn(D)
-h = Hamiltonian(UnitEuclideanMetric(θ_init), logπ, ∂logπ∂θ)
+h = Hamiltonian(UnitEuclideanMetric{Float64}(D), logπ, ∂logπ∂θ)
 prop = NUTS(Leapfrog(find_good_eps(h, θ_init)))
 r_init = AdvancedHMC.rand_momentum(h)
 


### PR DESCRIPTION
Removes `dim` as a field of `DiagEuclideanMetric` and `DenseEuclideanMetric` in favour of just using `getproperty` methods. This introduces some ambiguities, so we have to go with the following interface for construction:
```julia
UnitEuclideanMetric{Float64}(D)
DiagEuclideanMetric(::AbstractVector)
DenseEuclideanMetric(::AbstractMatrix)
```
and we've dropped the construct-with-element-from-space interface, which was really only a convenience thing anyway (as I understand it).