### PR TITLE
Support progress meter

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,3 +1,5 @@
+# This file is machine-generated - editing it directly is not advised
+
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
@@ -28,7 +30,7 @@ deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[Distributed]]
-deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[FillArrays]]
@@ -44,7 +46,7 @@ uuid = "505f98c9-085e-5b2c-8e89-488be7bf1f34"
 version = "0.3.0"
 
 [[InteractiveUtils]]
-deps = ["LinearAlgebra", "Markdown"]
+deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[LazyArrays]]
@@ -77,10 +79,10 @@ deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[Missings]]
-deps = ["Dates", "InteractiveUtils", "SparseArrays", "Test"]
-git-tree-sha1 = "d1d2585677f2bd93a97cfeb8faa7a0de0f982042"
+deps = ["SparseArrays", "Test"]
+git-tree-sha1 = "f0719736664b4358aa9ec173077d4285775f8007"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "0.4.0"
+version = "0.4.1"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
@@ -98,6 +100,12 @@ uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[ProgressMeter]]
+deps = ["Distributed", "Printf", "Random", "Test"]
+git-tree-sha1 = "48058bc11607676e5bbc0b974af79106c6200787"
+uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
+version = "0.9.0"
 
 [[REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets"]
@@ -157,7 +165,7 @@ uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 version = "0.5.3"
 
 [[UUIDs]]
-deps = ["Random"]
+deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]

--- a/Project.toml
+++ b/Project.toml
@@ -7,9 +7,13 @@ version = "0.1.5"
 InplaceOps = "505f98c9-085e-5b2c-8e89-488be7bf1f34"
 LazyArrays = "5078a376-72f3-5289-bfd5-ec5146d43c02"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+
+[compat]
+julia = ">= 1.0"
 
 [extras]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -20,6 +24,3 @@ Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [targets]
 test = ["Test", "Distributions", "ForwardDiff", "Turing", "Distributed"]
-
-[compat]
-julia = ">= 1.0"

--- a/src/AdvancedHMC.jl
+++ b/src/AdvancedHMC.jl
@@ -6,6 +6,7 @@ using Statistics: mean, var, middle
 using LinearAlgebra: Symmetric, UpperTriangular, mul!, ldiv!, dot, I, diag, cholesky
 using LazyArrays: BroadcastArray
 using Random: GLOBAL_RNG, AbstractRNG
+using ProgressMeter
 
 import StatsBase: sample
 

--- a/src/adaptation/Adaptation.jl
+++ b/src/adaptation/Adaptation.jl
@@ -7,6 +7,7 @@ import LinearAlgebra, Statistics
 using ..AdvancedHMC: DEBUG
 
 abstract type AbstractAdaptor end
+struct NoAdaptation <: AbstractAdaptor end
 
 include("stepsize.jl")
 include("precond.jl")

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -1,57 +1,46 @@
-sample(h::Hamiltonian, prop::AbstractProposal, θ::AbstractVector{T}, n_samples::Int; verbose::Bool=true) where {T<:Real} =
-    sample(GLOBAL_RNG, h, prop, θ, n_samples; verbose=verbose)
-
-function sample(rng::AbstractRNG, h::Hamiltonian, prop::AbstractProposal, θ::AbstractVector{T}, n_samples::Int; verbose::Bool=true) where {T<:Real}
-    θs = Vector{Vector{T}}(undef, n_samples)
-    Hs = Vector{T}(undef, n_samples)
-    αs = Vector{T}(undef, n_samples)
-    time = @elapsed for i = 1:n_samples
-        θs[i], Hs[i], αs[i] = step(rng, h, prop, i == 1 ? θ : θs[i-1])
-    end
-    verbose && @info "Finished sampling with $time (s)" typeof(h.metric) typeof(prop) EBFMI(Hs) mean(αs)
-    return θs
-end
-
-sample(h::Hamiltonian,
-    prop::AbstractProposal,
-    θ::AbstractVector{T},
-    n_samples::Int,
-    adaptor::Adaptation.AbstractAdaptor,
-    n_adapts::Int=min(div(n_samples, 10), 1_000);
-    verbose::Bool=true
-) where {T<:Real} = sample(GLOBAL_RNG, h, prop, θ, n_samples, adaptor, n_adapts; verbose=verbose)
-
-function sample(rng::AbstractRNG,
+sample(
     h::Hamiltonian,
     prop::AbstractProposal,
     θ::AbstractVector{T},
     n_samples::Int,
-    adaptor::Adaptation.AbstractAdaptor,
+    adaptor::Union{Nothing,Adaptation.AbstractAdaptor}=nothing,
     n_adapts::Int=min(div(n_samples, 10), 1_000);
-    verbose::Bool=true
+    verbose::Bool=true,
+    progress::Bool=false
+) where {T<:Real} = sample(GLOBAL_RNG, h, prop, θ, n_samples, adaptor, n_adapts; verbose=verbose, progress=progress)
+
+function sample(
+    rng::AbstractRNG,
+    h::Hamiltonian,
+    prop::AbstractProposal,
+    θ::AbstractVector{T},
+    n_samples::Int,
+    adaptor::Union{Nothing,Adaptation.AbstractAdaptor}=nothing,
+    n_adapts::Int=min(div(n_samples, 10), 1_000);
+    verbose::Bool=true,
+    progress::Bool=false
 ) where {T<:Real}
     θs = Vector{Vector{T}}(undef, n_samples)
     Hs = Vector{T}(undef, n_samples)
     αs = Vector{T}(undef, n_samples)
+    pm = progress ? nothing : Progress(n_samples, desc="Sampling", barlen=31)
     time = @elapsed for i = 1:n_samples
         θs[i], Hs[i], αs[i] = step(rng, h, prop, i == 1 ? θ : θs[i-1])
-        if i <= n_adapts
+        progress && (showvalues = [(:iteration, i), (:hamiltonian_energy, Hs[i]), (:acceptance_rate, αs[i])])
+        if !(adaptor === nothing) && i <= n_adapts
             adapt!(adaptor, θs[i], αs[i])
             h, prop = update(h, prop, adaptor)
-            if verbose
-                if i == n_adapts
-                    @info "Finished $n_adapts adapation steps" typeof(adaptor) prop.integrator.ϵ h.metric
-                elseif i % Int(n_adapts / 10) == 0
-                    @info "Adapting $i of $n_adapts steps" typeof(adaptor) prop.integrator.ϵ h.metric
-                end
-            end
+            progress && append!(showvalues, [(:step_size, prop.integrator.ϵ), (:precond, h.metric)])
+            verbose && i == n_adapts && @info "Finished $n_adapts adapation steps" typeof(adaptor) prop.integrator.ϵ h.metric
         end
+        progress && ProgressMeter.next!(pm; showvalues=showvalues)
     end
     verbose && @info "Finished $n_samples sampling steps in $time (s)" typeof(h.metric) typeof(prop) EBFMI(Hs) mean(αs)
     return θs
 end
 
-function step(rng::AbstractRNG,
+function step(
+    rng::AbstractRNG,
     h::Hamiltonian,
     prop::AbstractTrajectory{I},
     θ::AbstractVector{T}
@@ -62,7 +51,8 @@ function step(rng::AbstractRNG,
     return θ_new, H_new, α
 end
 
-step(h::Hamiltonian,
+step(
+    h::Hamiltonian,
     p::AbstractTrajectory,
     θ::AbstractVector{T}
 ) where {T<:Real} = step(GLOBAL_RNG, h, p, θ)

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -23,14 +23,14 @@ function sample(
     θs = Vector{Vector{T}}(undef, n_samples)
     Hs = Vector{T}(undef, n_samples)
     αs = Vector{T}(undef, n_samples)
-    pm = progress ? nothing : Progress(n_samples, desc="Sampling", barlen=31)
+    pm = progress ? Progress(n_samples, desc="Sampling", barlen=31) : nothing
     time = @elapsed for i = 1:n_samples
         θs[i], Hs[i], αs[i] = step(rng, h, prop, i == 1 ? θ : θs[i-1])
-        progress && (showvalues = [(:iteration, i), (:hamiltonian_energy, Hs[i]), (:acceptance_rate, αs[i])])
+        progress && (showvalues = Tuple[(:iteration, i), (:hamiltonian_energy, Hs[i]), (:acceptance_rate, αs[i])])
         if !(adaptor === nothing) && i <= n_adapts
             adapt!(adaptor, θs[i], αs[i])
             h, prop = update(h, prop, adaptor)
-            progress && append!(showvalues, [(:step_size, prop.integrator.ϵ), (:precond, h.metric)])
+            progress && append!(showvalues, [(:step_size, prop.integrator.ϵ), (:precondition, h.metric)])
             verbose && i == n_adapts && @info "Finished $n_adapts adapation steps" typeof(adaptor) prop.integrator.ϵ h.metric
         end
         progress && ProgressMeter.next!(pm; showvalues=showvalues)


### PR DESCRIPTION
- Add progress meter (https://github.com/TuringLang/AdvancedHMC.jl/issues/57)
  - Also add flag to turn on or off the progress meter. This allows AHMC to run in silent mode, which is very necessary for large scale parallel use of the sampler. FYI, a friend of mine has been using AHMC on a quite large dataset. He runs the sampler in parallel using 40 cores for > 2 hours, and so far it seems to be all good. He also checked the inference results to that he obtained from his VAE implemented and found they are very consistent.
- Remove old intermediate `@info` for adaptation
- Merged `sample()` for adapted and non-adaptive `sample()`