### PR TITLE
Fix adaptation for HMCDA

### DIFF
--- a/src/adaptation/Adaptation.jl
+++ b/src/adaptation/Adaptation.jl
@@ -7,6 +7,7 @@ import LinearAlgebra, Statistics
 using ..AdvancedHMC: DEBUG
 
 abstract type AbstractAdaptor end
+finalize!(::AbstractAdaptor) = nothing
 struct NoAdaptation <: AbstractAdaptor end
 
 include("stepsize.jl")
@@ -20,22 +21,26 @@ struct NaiveCompAdaptor <: AbstractCompositeAdaptor
     ssa :: StepSizeAdaptor
 end
 
-function adapt!(tp::NaiveCompAdaptor, θ::AbstractVector{<:Real}, α::AbstractFloat)
-    adapt!(tp.ssa, θ, α)
-    adapt!(tp.pc, θ, α)
+function adapt!(nca::NaiveCompAdaptor, θ::AbstractVector{<:Real}, α::AbstractFloat)
+    adapt!(nca.ssa, θ, α)
+    adapt!(nca.pc, θ, α)
 end
 
-function getM⁻¹(ca::AbstractCompositeAdaptor)
-    return getM⁻¹(ca.pc)
+function getM⁻¹(aca::AbstractCompositeAdaptor)
+    return getM⁻¹(aca.pc)
 end
 
-function getϵ(ca::AbstractCompositeAdaptor)
-    return getϵ(ca.ssa)
+function getϵ(aca::AbstractCompositeAdaptor)
+    return getϵ(aca.ssa)
+end
+
+function finalize!(aca::AbstractCompositeAdaptor)
+    finalize!(aca.ssa)
 end
 
 include("stan_adaption.jl")
 
-export adapt!, getϵ, getM⁻¹,
+export adapt!, finalize!, getϵ, getM⁻¹, 
        NesterovDualAveraging,
        UnitPreconditioner, DiagPreconditioner, DensePreconditioner,
        AbstractMetric, UnitEuclideanMetric, DiagEuclideanMetric, DenseEuclideanMetric,

--- a/src/adaptation/stan_adaption.jl
+++ b/src/adaptation/stan_adaption.jl
@@ -41,8 +41,6 @@ function is_window_end(tp::StanNUTSAdaptor)
            (tp.state.i != tp.n_adapts)
 end
 
-is_final(tp::StanNUTSAdaptor) = tp.state.i == tp.n_adapts
-
 function compute_next_window!(tp::StanNUTSAdaptor)
     if ~(tp.state.next_window == tp.n_adapts - tp.term_buffer - 1)
         tp.state.window_size *= 2
@@ -74,8 +72,8 @@ function adapt!(tp::StanNUTSAdaptor, θ::AbstractVector{<:Real}, α::AbstractFlo
         # If window ends, compute next window
         compute_next_window!(tp)
     end
+end
 
-    if is_final(tp)
-        finalize!(tp.ssa)
-    end
+function finalize!(adaptor::StanNUTSAdaptor)
+    finalize!(adaptor.ssa)
 end

--- a/src/adaptation/stepsize.jl
+++ b/src/adaptation/stepsize.jl
@@ -86,14 +86,14 @@ end
 # TODO: merge this function with adapt!
 function adapt_stepsize!(da::NesterovDualAveraging, α::AbstractFloat)
     DEBUG && @debug "Adapting step size..." α
-    da.state.m += 1
-    m = da.state.m
-
+    
     # Clip average MH acceptance probability
     α = α > 1 ? 1 : α
 
-    γ = da.γ; t_0 = da.t_0; κ = da.κ; δ = da.δ
+    m = da.state.m; γ = da.γ; t_0 = da.t_0; κ = da.κ; δ = da.δ
     μ = da.state.μ; x_bar = da.state.x_bar; H_bar = da.state.H_bar
+
+    m = m + 1
 
     η_H = 1.0 / (m + t_0)
     H_bar = (1.0 - η_H) * H_bar + η_H * (δ - α)
@@ -108,11 +108,13 @@ function adapt_stepsize!(da::NesterovDualAveraging, α::AbstractFloat)
     # TODO: we might want to remove this when all other numerical issues are correctly handelled
     if isnan(ϵ) || isinf(ϵ)
         @warn "Incorrect ϵ = $ϵ; ϵ_previous = $(da.state.ϵ) is used instead."
+        m = da.state.m
         ϵ = da.state.ϵ
         x_bar = da.state.x_bar
         H_bar = da.state.H_bar
     end
 
+    da.state.m = m
     da.state.ϵ = ϵ
     da.state.x_bar = x_bar
     da.state.H_bar = H_bar

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -73,7 +73,7 @@ function transition(
     z::PhasePoint
 ) where {T<:Real}
     # Create the corresponding static τ
-    n_steps = max(1, round(Int, τ.λ / τ.integrator.ϵ))
+    n_steps = max(1, floor(Int, τ.λ / τ.integrator.ϵ))
     static_τ = StaticTrajectory(τ.integrator, n_steps)
     return transition(rng, static_τ, h, z)
 end

--- a/test/hmc.jl
+++ b/test/hmc.jl
@@ -1,3 +1,6 @@
+# Allow pass --progress when running this script individually to turn on progress meter
+const PROGRESS = length(ARGS) > 0 && ARGS[1] == "--progress" ? true : false
+
 using Test, AdvancedHMC, LinearAlgebra
 using Statistics: mean, var, cov
 include("common.jl")
@@ -20,9 +23,9 @@ n_adapts = 2_000
             HMCDA(Leapfrog(ϵ), ϵ * n_steps),
             NUTS(Leapfrog(find_good_eps(h, θ_init))),
         ]
-            @info "HMC and NUTS numerical test" typeof(τ) n_samples
-            samples = sample(h, τ, θ_init, n_samples; verbose=false)
+            samples = sample(h, τ, θ_init, n_samples; verbose=false, progress=PROGRESS)
             @test mean(samples[n_adapts+1:end]) ≈ zeros(D) atol=RNDATOL
+
             @testset "$(typeof(adaptor))" for adaptor in [
                 Preconditioner(metric),
                 NesterovDualAveraging(0.8, τ.integrator.ϵ),
@@ -36,8 +39,7 @@ n_adapts = 2_000
                     NesterovDualAveraging(0.8, τ.integrator.ϵ),
                 ),
             ]
-                @info "HMC and NUTS numerical test" typeof(τ) n_samples typeof(adaptor) typeof(metric) n_adapts
-                samples = sample(h, τ, θ_init, n_samples, adaptor, n_adapts; verbose=false)
+                samples = sample(h, τ, θ_init, n_samples, adaptor, n_adapts; verbose=false, progress=PROGRESS)
                 @test mean(samples[n_adapts+1:end]) ≈ zeros(D) atol=RNDATOL
             end
         end


### PR DESCRIPTION
- Add `finalize!` to all adaptors
  - HMCDA shall use `NaiveCompositeAdaptor` instead of Stan's windowed.
- Fix a bug in progress meter for which it only shows adaptation stats during adaptation but not afterwards.
- Small clean-ups in step size adaptation (no functional change).