### PR TITLE
Bugfix for pre-conditioner dimensionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ n_adapts = 2_000
 metric = DenseEuclideanMetric(D)
 h = Hamiltonian(metric, logπ, ∂logπ∂θ)
 prop = NUTS(Leapfrog(find_good_eps(h, θ_init)))
-adaptor = StanNUTSAdaptor(n_adapts, Preconditioner(metric), NesterovDualAveraging(0.8, prop.integrator.ϵ))
+adaptor = StanHMCAdaptor(n_adapts, Preconditioner(metric), NesterovDualAveraging(0.8, prop.integrator.ϵ))
 
 # Sampling
 samples = sample(h, prop, θ_init, n_samples, adaptor, n_adapts)

--- a/src/AdvancedHMC.jl
+++ b/src/AdvancedHMC.jl
@@ -19,7 +19,7 @@ import StatsBase: sample
 
 include("adaptation/Adaptation.jl")
 export UnitEuclideanMetric, DiagEuclideanMetric, DenseEuclideanMetric
-export NesterovDualAveraging, Preconditioner, NaiveCompAdaptor, StanNUTSAdaptor
+export NesterovDualAveraging, Preconditioner, NaiveHMCAdaptor, StanHMCAdaptor
 using .Adaptation
 
 include("hamiltonian.jl")

--- a/src/adaptation/Adaptation.jl
+++ b/src/adaptation/Adaptation.jl
@@ -7,7 +7,22 @@ import LinearAlgebra, Statistics
 using ..AdvancedHMC: DEBUG
 
 abstract type AbstractAdaptor end
+
+##
+## Interface for adaptors
+##
+
+adapt!(
+    ::AbstractAdaptor,
+    ::AbstractVector{T},
+    ::AbstractFloat,
+    is_update::Bool=true
+) where {T<:<:Real}       = nothing
+getM⁻¹(::AbstractAdaptor) = nothing
+getϵ(::AbstractAdaptor)   = nothing
+reset!(::AbstractAdaptor) = nothing
 finalize!(::AbstractAdaptor) = nothing
+
 struct NoAdaptation <: AbstractAdaptor end
 
 include("stepsize.jl")
@@ -40,7 +55,7 @@ end
 
 include("stan_adaption.jl")
 
-export adapt!, finalize!, getϵ, getM⁻¹, 
+export adapt!, finalize!, getϵ, getM⁻¹,
        NesterovDualAveraging,
        UnitPreconditioner, DiagPreconditioner, DensePreconditioner,
        AbstractMetric, UnitEuclideanMetric, DiagEuclideanMetric, DenseEuclideanMetric,

--- a/src/adaptation/Adaptation.jl
+++ b/src/adaptation/Adaptation.jl
@@ -34,8 +34,8 @@ include("precond.jl")
 ## TODO: generalise this to a list of adaptors
 ##
 
-struct NaiveHMCAdaptor <: AbstractAdaptor
-    pc  :: AbstractPreconditioner
+struct NaiveHMCAdaptor{M<:AbstractPreconditioner} <: AbstractAdaptor
+    pc  :: M
     ssa :: StepSizeAdaptor
 end
 

--- a/src/adaptation/Adaptation.jl
+++ b/src/adaptation/Adaptation.jl
@@ -17,7 +17,7 @@ adapt!(
     ::AbstractVector{T},
     ::AbstractFloat,
     is_update::Bool=true
-) where {T<:<:Real}       = nothing
+) where {T<:Real}       = nothing
 getM⁻¹(::AbstractAdaptor) = nothing
 getϵ(::AbstractAdaptor)   = nothing
 reset!(::AbstractAdaptor) = nothing
@@ -28,37 +28,38 @@ struct NoAdaptation <: AbstractAdaptor end
 include("stepsize.jl")
 include("precond.jl")
 
-abstract type AbstractCompositeAdaptor <: AbstractAdaptor end
 
-# TODO: generalise this to a list of adaptors
-struct NaiveCompAdaptor <: AbstractCompositeAdaptor
+##
+## Compositional adaptor
+## TODO: generalise this to a list of adaptors
+##
+
+struct NaiveHMCAdaptor <: AbstractAdaptor
     pc  :: AbstractPreconditioner
     ssa :: StepSizeAdaptor
 end
 
-function adapt!(nca::NaiveCompAdaptor, θ::AbstractVector{<:Real}, α::AbstractFloat)
+getM⁻¹(aca::NaiveHMCAdaptor) = getM⁻¹(aca.pc)
+getϵ(aca::NaiveHMCAdaptor)   = getϵ(aca.ssa)
+finalize!(aca::NaiveHMCAdaptor) = finalize!(aca.ssa)
+function adapt!(nca::NaiveHMCAdaptor, θ::AbstractVector{<:Real}, α::AbstractFloat)
     adapt!(nca.ssa, θ, α)
     adapt!(nca.pc, θ, α)
 end
-
-function getM⁻¹(aca::AbstractCompositeAdaptor)
-    return getM⁻¹(aca.pc)
+function reset!(aca::NaiveHMCAdaptor)
+    reset!(aca.ssa)
+    reset!(aca.pc)
 end
 
-function getϵ(aca::AbstractCompositeAdaptor)
-    return getϵ(aca.ssa)
-end
-
-function finalize!(aca::AbstractCompositeAdaptor)
-    finalize!(aca.ssa)
-end
-
+##
+## Stan's windowed adaptor.
+##
 include("stan_adaption.jl")
 
-export adapt!, finalize!, getϵ, getM⁻¹,
+export adapt!, finalize!, getϵ, getM⁻¹, reset!,
        NesterovDualAveraging,
        UnitPreconditioner, DiagPreconditioner, DensePreconditioner,
        AbstractMetric, UnitEuclideanMetric, DiagEuclideanMetric, DenseEuclideanMetric,
-       Preconditioner, NaiveCompAdaptor, StanNUTSAdaptor
+       Preconditioner, NaiveHMCAdaptor, StanHMCAdaptor
 
 end # module

--- a/src/adaptation/stan_adaption.jl
+++ b/src/adaptation/stan_adaption.jl
@@ -70,6 +70,7 @@ function adapt!(tp::StanHMCAdaptor, θ::AbstractVector{<:Real}, α::AbstractFloa
 
     adapt!(tp.ssa, θ, α)
 
+    resize!(tp.pc, θ) # Resize pre-conditioner if necessary.
     # Ref: https://github.com/stan-dev/stan/blob/develop/src/stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp
     if is_in_window(tp)
         # We accumlate stats from θ online and only trigger the update of M⁻¹ in the end of window.

--- a/src/adaptation/stan_adaption.jl
+++ b/src/adaptation/stan_adaption.jl
@@ -23,8 +23,14 @@ struct StanHMCAdaptor{M<:AbstractPreconditioner} <: AbstractAdaptor
     state       :: StanHMCAdaptorState
 end
 
-function StanHMCAdaptor(n_adapts::Int, pc::AbstractPreconditioner, ssa::StepSizeAdaptor,
-                         init_buffer::Int=75, term_buffer::Int=50, window_size::Int=25)
+function StanHMCAdaptor(
+    n_adapts::Int,
+    pc::M,
+    ssa::StepSizeAdaptor,
+    init_buffer::Int=75,
+    term_buffer::Int=50,
+    window_size::Int=25
+) where {M<:AbstractPreconditioner}
     next_window = init_buffer + window_size - 1
     return StanHMCAdaptor(n_adapts, pc, ssa, init_buffer, term_buffer, StanHMCAdaptorState(0, window_size, next_window))
 end
@@ -57,7 +63,7 @@ end
 getM⁻¹(adaptor::StanHMCAdaptor) = getM⁻¹(adaptor.pc)
 getϵ(adaptor::StanHMCAdaptor)   = getϵ(adaptor.ssa)
 finalize!(adaptor::StanHMCAdaptor) = finalize!(adaptor.ssa)
-# reset!(adaptor::StanHMCAdaptor) # Not used. 
+# reset!(adaptor::StanHMCAdaptor) # Not used.
 
 function adapt!(tp::StanHMCAdaptor, θ::AbstractVector{<:Real}, α::AbstractFloat)
     tp.state.i += 1

--- a/src/adaptation/stan_adaption.jl
+++ b/src/adaptation/stan_adaption.jl
@@ -2,7 +2,7 @@
 ### Mutable states ###
 ######################
 
-mutable struct ThreePhaseState
+mutable struct StanHMCAdaptorState
     i           :: Int
     window_size :: Int
     next_window :: Int
@@ -12,36 +12,36 @@ end
 ### Adaptors ###
 ################
 
-# TODO: currently only StanNUTSAdaptor has the filed `n_adapts`. maybe we could unify all
+# TODO: currently only StanHMCAdaptor has the filed `n_adapts`. maybe we could unify all
 # Acknowledgement: this adaption settings is mimicing Stan's 3-phase adaptation.
-struct StanNUTSAdaptor{M<:AbstractPreconditioner} <: AbstractCompositeAdaptor
+struct StanHMCAdaptor{M<:AbstractPreconditioner} <: AbstractAdaptor
     n_adapts    :: Int
     pc          :: M
     ssa         :: StepSizeAdaptor
     init_buffer :: Int
     term_buffer :: Int
-    state       :: ThreePhaseState
+    state       :: StanHMCAdaptorState
 end
 
-function StanNUTSAdaptor(n_adapts::Int, pc::AbstractPreconditioner, ssa::StepSizeAdaptor,
+function StanHMCAdaptor(n_adapts::Int, pc::AbstractPreconditioner, ssa::StepSizeAdaptor,
                          init_buffer::Int=75, term_buffer::Int=50, window_size::Int=25)
     next_window = init_buffer + window_size - 1
-    return StanNUTSAdaptor(n_adapts, pc, ssa, init_buffer, term_buffer, ThreePhaseState(0, window_size, next_window))
+    return StanHMCAdaptor(n_adapts, pc, ssa, init_buffer, term_buffer, StanHMCAdaptorState(0, window_size, next_window))
 end
 
 # Ref: https://github.com/stan-dev/stan/blob/develop/src/stan/mcmc/windowed_adaptation.hpp
-function is_in_window(tp::StanNUTSAdaptor)
+function is_in_window(tp::StanHMCAdaptor)
     return (tp.state.i >= tp.init_buffer) &&
            (tp.state.i < tp.n_adapts - tp.term_buffer) &&
            (tp.state.i != tp.n_adapts)
 end
 
-function is_window_end(tp::StanNUTSAdaptor)
+function is_window_end(tp::StanHMCAdaptor)
     return (tp.state.i == tp.state.next_window) &&
            (tp.state.i != tp.n_adapts)
 end
 
-function compute_next_window!(tp::StanNUTSAdaptor)
+function compute_next_window!(tp::StanHMCAdaptor)
     if ~(tp.state.next_window == tp.n_adapts - tp.term_buffer - 1)
         tp.state.window_size *= 2
         tp.state.next_window = tp.state.i + tp.state.window_size
@@ -54,7 +54,12 @@ function compute_next_window!(tp::StanNUTSAdaptor)
     end
 end
 
-function adapt!(tp::StanNUTSAdaptor, θ::AbstractVector{<:Real}, α::AbstractFloat)
+getM⁻¹(adaptor::StanHMCAdaptor) = getM⁻¹(adaptor.pc)
+getϵ(adaptor::StanHMCAdaptor)   = getϵ(adaptor.ssa)
+finalize!(adaptor::StanHMCAdaptor) = finalize!(adaptor.ssa)
+# reset!(adaptor::StanHMCAdaptor) # Not used. 
+
+function adapt!(tp::StanHMCAdaptor, θ::AbstractVector{<:Real}, α::AbstractFloat)
     tp.state.i += 1
 
     adapt!(tp.ssa, θ, α)
@@ -72,8 +77,4 @@ function adapt!(tp::StanNUTSAdaptor, θ::AbstractVector{<:Real}, α::AbstractFlo
         # If window ends, compute next window
         compute_next_window!(tp)
     end
-end
-
-function finalize!(adaptor::StanNUTSAdaptor)
-    finalize!(adaptor.ssa)
 end

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -51,7 +51,6 @@ function sample(
             progress && append!(showvalues, [(:step_size, τ.integrator.ϵ), (:precondition, h.metric)])
         end
         progress && ProgressMeter.next!(pm; showvalues=showvalues)
-        h = update(h, θ) # Ensure h.metric has the same dim as θ.
         # Refresh momentum for next iteration
         z = rand_momentum(rng, z, h)
     end

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -40,12 +40,12 @@ function sample(
         if !(adaptor isa Adaptation.NoAdaptation)
             if i <= n_adapts
                 adapt!(adaptor, θs[i], αs[i])
-                h, τ = update(h, τ, adaptor)
                 # Finalize adapation
                 if i == n_adapts
                     finalize!(adaptor)
                     verbose && @info "Finished $n_adapts adapation steps" typeof(adaptor) τ.integrator.ϵ h.metric
                 end
+                h, τ = update(h, τ, adaptor)
             end
             # Progress info for adapation
             progress && append!(showvalues, [(:step_size, τ.integrator.ϵ), (:precondition, h.metric)])

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -29,6 +29,7 @@ function sample(
     Hs = Vector{T}(undef, n_samples)
     αs = Vector{T}(undef, n_samples)
     # Prepare phase point for sampling
+    h = update(h, θ) # Ensure h.metric has the same dim as θ.
     r = rand(rng, h.metric)
     z = phasepoint(h, θ, r)
     pm = progress ? Progress(n_samples, desc="Sampling", barlen=31) : nothing
@@ -50,6 +51,7 @@ function sample(
             progress && append!(showvalues, [(:step_size, τ.integrator.ϵ), (:precondition, h.metric)])
         end
         progress && ProgressMeter.next!(pm; showvalues=showvalues)
+        h = update(h, θ) # Ensure h.metric has the same dim as θ.
         # Refresh momentum for next iteration
         z = rand_momentum(rng, z, h)
     end

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -305,7 +305,7 @@ update(
 update(
     h::Hamiltonian,
     τ::AbstractProposal,
-    ca::Adaptation.AbstractCompositeAdaptor
+    ca::Union{Adaptation.NaiveHMCAdaptor, Adaptation.StanHMCAdaptor}
 ) = h(getM⁻¹(ca.pc)), τ(τ.integrator(getϵ(ca.ssa)))
 
 function update(

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -10,9 +10,8 @@ abstract type AbstractTrajectory{I<:AbstractIntegrator} <: AbstractProposal end
 transition(
     τ::AbstractTrajectory{I},
     h::Hamiltonian,
-    θ::AbstractVector{T},
-    r::AbstractVector{T}
-) where {I<:AbstractIntegrator,T<:Real} = transition(GLOBAL_RNG, τ, h, θ, r)
+    z::PhasePoint
+) where {I<:AbstractIntegrator,T<:Real} = transition(GLOBAL_RNG, τ, h, z)
 
 ###
 ### Standard HMC implementation with fixed leapfrog step numbers.
@@ -202,10 +201,8 @@ end
 
 transition(nt::DynamicTrajectory{I},
     h::Hamiltonian,
-    θ::AbstractVector{T},
-    r::AbstractVector{T}
-) where {I<:AbstractIntegrator,T<:Real} = transition(GLOBAL_RNG, nt, h, θ, r)
-
+    z::PhasePoint
+) where {I<:AbstractIntegrator,T<:Real} = transition(GLOBAL_RNG, nt, h, z)
 
 ##
 ## API: required by Turing.Gibbs

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -308,7 +308,10 @@ update(
     ca::Adaptation.AbstractCompositeAdaptor
 ) = h(getM⁻¹(ca.pc)), τ(τ.integrator(getϵ(ca.ssa)))
 
-function update(h::Hamiltonian, θ::AbstractVector{<:Real})
+function update(
+    h::Hamiltonian,
+    θ::AbstractVector{T}
+) where {T<:Real}
     metric = h.metric
     if length(metric) != length(θ)
         metric = metric(length(θ))

--- a/test/adaptation/precond.jl
+++ b/test/adaptation/precond.jl
@@ -52,3 +52,29 @@ end
     @test AdvancedHMC.Adaptation.getM⁻¹(pc2) == zeros(length(θ))
     @test AdvancedHMC.Adaptation.getM⁻¹(pc3) == LinearAlgebra.diagm(0 => ones(length(θ)))
 end
+
+@testset "Stan HMC adaptors" begin
+    θ = [0.0, 0.0, 0.0, 0.0]
+
+    adaptor1 = StanHMCAdaptor(
+        1000,
+        Preconditioner(UnitEuclideanMetric),
+        NesterovDualAveraging(0.8, 0.5)
+    )
+    adaptor2 = StanHMCAdaptor(
+        1000,
+        Preconditioner(DiagEuclideanMetric),
+        NesterovDualAveraging(0.8, 0.5)
+    )
+    adaptor3 = StanHMCAdaptor(
+        1000,
+        Preconditioner(DenseEuclideanMetric),
+        NesterovDualAveraging(0.8, 0.5)
+    )
+
+    AdvancedHMC.adapt!(adaptor1, θ, 1.)
+    AdvancedHMC.adapt!(adaptor2, θ, 1.)
+    AdvancedHMC.adapt!(adaptor3, θ, 1.)
+    @test AdvancedHMC.Adaptation.getM⁻¹(adaptor2) == zeros(length(θ))
+    @test AdvancedHMC.Adaptation.getM⁻¹(adaptor3) == LinearAlgebra.diagm(0 => ones(length(θ)))
+end

--- a/test/hmc.jl
+++ b/test/hmc.jl
@@ -29,11 +29,11 @@ n_adapts = 2_000
             @testset "$(typeof(adaptor))" for adaptor in [
                 Preconditioner(metric),
                 NesterovDualAveraging(0.8, τ.integrator.ϵ),
-                NaiveCompAdaptor(
+                NaiveHMCAdaptor(
                     Preconditioner(metric),
                     NesterovDualAveraging(0.8, τ.integrator.ϵ),
                 ),
-                StanNUTSAdaptor(
+                StanHMCAdaptor(
                     n_adapts,
                     Preconditioner(metric),
                     NesterovDualAveraging(0.8, τ.integrator.ϵ),


### PR DESCRIPTION
Bugfixes for issues identified in https://github.com/TuringLang/Turing.jl/pull/791 + some refactoring for adaption types (some further refactoring for adaption will be in a separate PR).

~~The dimensionality issue for preconditioning requires some further investigation.~~

UPDATE: The bug was that `adapt!` for `StanHMCAdaptor` only check and update dimensionality for pre-conditioner after `init_buffer`, i.e.

https://github.com/TuringLang/AdvancedHMC.jl/blob/34d7698d64aae9651a3042b60e46bcc3f0e56d8a/src/adaptation/stan_adaption.jl#L34-L36

and 

https://github.com/TuringLang/AdvancedHMC.jl/blob/34d7698d64aae9651a3042b60e46bcc3f0e56d8a/src/adaptation/stan_adaption.jl#L63-L67

This is now fixed by always checking dimensionality inside `adapt!`. Some additional tests for dimentionality checking area also added. 

https://github.com/TuringLang/AdvancedHMC.jl/blob/5c6929d292841efb10be05f9895e2e53d5ba4a8b/src/adaptation/stan_adaption.jl#L73