### PR TITLE
Perf boost: type stability and reducing allocations

### DIFF
--- a/src/AdvancedHMC.jl
+++ b/src/AdvancedHMC.jl
@@ -3,7 +3,7 @@ module AdvancedHMC
 const DEBUG = Bool(parse(Int, get(ENV, "DEBUG_AHMC", "0")))
 
 using Statistics: mean, var, middle
-using LinearAlgebra: Symmetric, UpperTriangular, mul!, ldiv!, dot, I, diag, cholesky
+using LinearAlgebra: Symmetric, UpperTriangular, mul!, ldiv!, dot, I, diag, cholesky, rmul!
 using LazyArrays: BroadcastArray
 using Random: GLOBAL_RNG, AbstractRNG
 using ProgressMeter

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -14,26 +14,28 @@ function (::Leapfrog)(ϵ::AbstractFloat)
     return Leapfrog(ϵ)
 end
 
-# TODO: double check the function below to see if it is type stable or not
-function step(
+function step!(
+    z_temp::PhasePoint,
     lf::Leapfrog{F},
     h::Hamiltonian,
     z::PhasePoint,
     n_steps::Int=1;
     fwd = n_steps > 0 # Simulate hamiltonian backward when n_steps < 0
 ) where {F<:AbstractFloat,T<:Real}
-    @unpack θ, r = z
+    @unpack θ, r = z_temp
+    θ .= z.θ
+    r .= z.r
     ϵ = fwd ? lf.ϵ : -lf.ϵ
 
-    ∇θ = ∂H∂θ(h, θ)
+    ∇θ = ∂H∂θ!(h, θ)
     for i = 1:abs(n_steps)
-        r = r - ϵ/2 * ∇θ # Take a half leapfrog step for momentum variable
-        ∇r = ∂H∂r(h, r)
-        θ = θ + ϵ * ∇r   # Take a full leapfrog step for position variable
-        ∇θ = ∂H∂θ(h, θ)
-        r = r - ϵ/2 * ∇θ # Take a half leapfrog step for momentum variable
+        r .= r .- ϵ/2 .* ∇θ # Take a half leapfrog step for momentum variable
+        ∇r = ∂H∂r!(h, r)
+        θ .= θ .+ ϵ .* ∇r   # Take a full leapfrog step for position variable
+        ∇θ = ∂H∂θ!(h, θ)
+        r .= r .- ϵ/2 .* ∇θ # Take a half leapfrog step for momentum variable
         z = phasepoint(h, θ, r)
         !isfinite(z) && break
     end
-    return z
+    return deepcopy(z)
 end

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -32,9 +32,10 @@ function sample(
     h = update(h, θ) # Ensure h.metric has the same dim as θ.
     r = rand(rng, h.metric)
     z = phasepoint(h, θ, r)
+    z_temp = deepcopy(z)
     pm = progress ? Progress(n_samples, desc="Sampling", barlen=31) : nothing
     time = @elapsed for i = 1:n_samples
-        z, αs[i] = transition(rng, τ, h, z)
+        z, αs[i] = transition(rng, z_temp, τ, h, z)
         θs[i], Hs[i] = z.θ, neg_energy(z)
         progress && (showvalues = Tuple[(:iteration, i), (:hamiltonian_energy, Hs[i]), (:acceptance_rate, αs[i])])
         if !(adaptor isa Adaptation.NoAdaptation)

--- a/test/common.jl
+++ b/test/common.jl
@@ -12,4 +12,4 @@ using Distributions: logpdf, MvNormal
 using ForwardDiff: gradient
 
 logπ(θ::AbstractVector{T}) where {T<:Real} = logpdf(MvNormal(zeros(D), ones(D)), θ)
-∂logπ∂θ = θ -> gradient(logπ, θ)
+∂logπ∂θ = (g, θ) -> (g .= gradient(logπ, θ); g)

--- a/test/proposal.jl
+++ b/test/proposal.jl
@@ -14,11 +14,12 @@ r_init = AdvancedHMC.rand(h.metric)
     for seed in [1234, 5678, 90]
         rng = MersenneTwister(seed)
         z = AdvancedHMC.phasepoint(h, θ_init, r_init)
-        z1′, _ = AdvancedHMC.transition(rng, τ, h, z)
+        z_temp = deepcopy(z)
+        z1′, _ = AdvancedHMC.transition(rng, z_temp, τ, h, z)
 
         rng = MersenneTwister(seed)
         z = AdvancedHMC.phasepoint(h, θ_init, r_init)
-        z2′, _ = AdvancedHMC.transition(rng, τ, h, z)
+        z2′, _ = AdvancedHMC.transition(rng, z_temp, τ, h, z)
 
         @test z1′.θ == z2′.θ
         @test z1′.r == z2′.r


### PR DESCRIPTION
This PR fixes the remaining AHMC type stability issues and reduces some unnecessary allocations. Some basic benchmark with 100_000 samples shows a speedup of around 33% and a reduction in allocations by around 27%.