### PR TITLE
Fixed bug preventing StanHMCAdaptor from adapting

### DIFF
--- a/src/adaptation/precond.jl
+++ b/src/adaptation/precond.jl
@@ -139,7 +139,7 @@ getM⁻¹(dpc::UnitPreconditioner{T}) where {T} = one(T)
 adapt!(
     ::UnitPreconditioner,
     ::AbstractVector{<:Real},
-    ::AbstractFloat;
+    ::AbstractFloat,
     is_update::Bool=true
 ) = nothing
 
@@ -164,7 +164,7 @@ getM⁻¹(dpc::DiagPreconditioner) = dpc.var
 function adapt!(
     dpc::DiagPreconditioner,
     θ::AbstractVector{T},
-    α::AbstractFloat;
+    α::AbstractFloat,
     is_update::Bool=true
 ) where {T<:Real}
     resize!(dpc, θ)
@@ -197,7 +197,7 @@ getM⁻¹(dpc::DensePreconditioner) = dpc.covar
 function adapt!(
     dpc::DensePreconditioner,
     θ::AbstractVector{T},
-    α::AbstractFloat;
+    α::AbstractFloat,
     is_update::Bool=true
 ) where {T<:AbstractFloat}
     resize!(dpc, θ)


### PR DESCRIPTION
StanHMCAdaptor was using positional arguments, but all the relevant signatures had keyword arguments. There was a generic fallback signature with positional arguments that was just a `nothing` stub, and it was always called instead. Turning the keyword args into positional args lets them be called instead, so that `StanHMCAdaptor` will now in fact adapt.

I'm not sure if it's wise to actually have that fallback. I'd think an error is preferable.