### PR TITLE
Bugfix for the use of metric

### DIFF
--- a/src/AdvancedHMC.jl
+++ b/src/AdvancedHMC.jl
@@ -3,7 +3,7 @@ module AdvancedHMC
 const DEBUG = Bool(parse(Int, get(ENV, "DEBUG_AHMC", "0")))
 
 using Statistics: mean, var, middle
-using LinearAlgebra: Symmetric, UpperTriangular, mul!, ldiv!, dot, I, diag, cholesky
+using LinearAlgebra: Symmetric, UpperTriangular, mul!, dot, I, diag, cholesky
 using LazyArrays: BroadcastArray
 using Random: GLOBAL_RNG, AbstractRNG
 using ProgressMeter

--- a/src/adaptation/precond.jl
+++ b/src/adaptation/precond.jl
@@ -331,7 +331,7 @@ function Base.rand(
     metric::DiagEuclideanMetric{T}
 ) where {T}
     r = randn(rng, T, metric.dim)
-    r ./= metric.sqrtM⁻¹
+    r .*= metric.sqrtM⁻¹
     return r
 end
 
@@ -340,7 +340,7 @@ function Base.rand(
     metric::DenseEuclideanMetric{T}
 ) where {T}
     r = randn(rng, T, metric.dim)
-    ldiv!(metric.cholM⁻¹, r)
+    mul!(r, metric.cholM⁻¹, r)
     return r
 end
 

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -21,8 +21,8 @@ function ∂H∂θ(h::Hamiltonian, θ::AbstractVector)
 end
 
 ∂H∂r(h::Hamiltonian{<:UnitEuclideanMetric}, r::AbstractVector) = copy(r)
-∂H∂r(h::Hamiltonian{<:DiagEuclideanMetric}, r::AbstractVector) = h.metric.M⁻¹ .* r
-∂H∂r(h::Hamiltonian{<:DenseEuclideanMetric}, r::AbstractVector) = h.metric.M⁻¹ * r
+∂H∂r(h::Hamiltonian{<:DiagEuclideanMetric}, r::AbstractVector) = h.metric.sqrtM⁻¹ .* r
+∂H∂r(h::Hamiltonian{<:DenseEuclideanMetric}, r::AbstractVector) = h.metric.cholM⁻¹ * r
 
 struct PhasePoint{T<:AbstractVector, V<:DualValue}
     θ::T  # Position variables / model parameters.
@@ -62,30 +62,7 @@ Base.isfinite(z::PhasePoint) = isfinite(z.ℓπ) && isfinite(z.ℓκ)
 neg_energy(z::PhasePoint) = z.ℓπ.value + z.ℓκ.value
 
 neg_energy(h::Hamiltonian, θ::AbstractVector) = h.ℓπ(θ)
-
-neg_energy(
-    h::Hamiltonian{<:UnitEuclideanMetric},
-    r::T,
-    θ::T
-) where {T<:AbstractVector} = -sum(abs2, r) / 2
-
-function neg_energy(
-    h::Hamiltonian{<:DiagEuclideanMetric},
-    r::T,
-    θ::T
-) where {T<:AbstractVector}
-    _r = [abs2(r[i]) * h.metric.M⁻¹[i] for i in 1:length(r)]
-    return -sum(_r) / 2
-end
-
-function neg_energy(
-    h::Hamiltonian{<:DenseEuclideanMetric},
-    r::T,
-    θ::T
-) where {T<:AbstractVector}
-    mul!(h.metric._temp, h.metric.M⁻¹, r)
-    return -dot(r, h.metric._temp) / 2
-end
+neg_energy(h::Hamiltonian, r::T, θ::T) where {T<:AbstractVector} = -sum(abs2, r) / 2
 
 ####
 #### Momentum sampler

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -65,9 +65,11 @@ function sample(
                 # Finalize adapation
                 if i == n_adapts
                     finalize!(adaptor)
+                    h, τ = update(h, τ, adaptor)
                     (verbose && !progress) && @info "Finished $n_adapts adapation steps" adaptor τ.integrator h.metric
+                else
+                    h, τ = update(h, τ, adaptor)
                 end
-                h, τ = update(h, τ, adaptor)
             end
             # Progress info for adapation
             progress && (showvalues[:step_size] = τ.integrator.ϵ; showvalues[:precondition] = h.metric)


### PR DESCRIPTION
Our code for how to use the metric (aka M_inverse) was based on Stan's. For a long time, we found our diag and dense preconditioning behaves weridly. This is still true for the current master and I meet this issue when running integrated test on Turing.jl again today, even in gdemo.

After checking Section 4.2.1 of Michael's paper again, I don't see any clue how would Stan's way to use M_inverse would work (at least in our current setting). So I changed it based on my current understanding and at least it works normally on gdemo now.

Below is what I did:
- When sample momentum, I return the momentum variable in the transformed space.
  - The transformation is the one in Michael's paper instead of the previous one. The difference is whether we multiply or divide r by M_inverse.
  - I think @yebai was trying to do the same thing before but we ended up following Stan's code.
- When compute grad_r that is needed to update q, I transform grad_r back to its original space.
  - By doing so, the update of q is just as normal.
- Nowhere else need to use M_inverse.
  - The changes in energy are cancelled and we only use Hamiltonian as a sum of two energy.
    - End of page 30 of https://arxiv.org/pdf/1701.02434.pdf is the one for knetic energy, and for potential energy it's just the origional - log(abs(det(jacob)), the latter of which is cancelled.
  - The logabsdetjacob in potential space doesn't matter as it's a constant w.r.t potential variable thus will be 0 when we take the gradient.