### PR TITLE
Working with CuArrays

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -49,6 +49,17 @@ phasepoint(
     ℓκ=DualValue(neg_energy(h, r, θ), ∂H∂r(h, r))
 ) where {T<:AbstractVector} = PhasePoint(θ, r, ℓπ, ℓκ)
 
+# If position variable and momentum variable are in different container,
+# move the momentum variable to that of the position variable.
+# This is neeced for AHMC to work with CuArrays (without depending on it).
+phasepoint(
+    h::Hamiltonian,
+    θ::T1,
+    _r::T2;
+    r=T1(_r),
+    ℓπ=∂H∂θ(h, θ),
+    ℓκ=DualValue(neg_energy(h, r, θ), ∂H∂r(h, r))
+) where {T1<:AbstractVector,T2<:AbstractVector} = PhasePoint(θ, r, ℓπ, ℓκ)
 
 Base.isfinite(v::DualValue) = all(isfinite, v.value) && all(isfinite, v.gradient)
 Base.isfinite(v::AbstractVector) = all(isfinite, v)

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -49,9 +49,9 @@ phasepoint(
     ℓκ=DualValue(neg_energy(h, r, θ), ∂H∂r(h, r))
 ) where {T<:AbstractVector} = PhasePoint(θ, r, ℓπ, ℓκ)
 
-# If position variable and momentum variable are in different container,
+# If position variable and momentum variable are in different containers,
 # move the momentum variable to that of the position variable.
-# This is neeced for AHMC to work with CuArrays (without depending on it).
+# This is needed for AHMC to work with CuArrays (without depending on it).
 phasepoint(
     h::Hamiltonian,
     θ::T1,

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -425,9 +425,9 @@ function find_good_eps(
     max_n_iters::Int=100
 ) where {T<:Real}
     # Initialize searching parameters
-    ϵ′ = ϵ = 0.1
-    a_min, a_cross, a_max = 0.25, 0.5, 0.75 # minimal, crossing, maximal accept ratio
-    d = 2.0
+    ϵ′ = ϵ = T(0.1)
+    a_min, a_cross, a_max = T(0.25), T(0.5), T(0.75) # minimal, crossing, maximal accept ratio
+    d = T(2.0)
     # Create starting phase point
     r = rand(rng, h.metric) # sample momentum variable
     z = phasepoint(h, θ, r)


### PR DESCRIPTION
All the containers in AHMC are typed as `AbstractVector` so passing `CuArray` is fine. 
The only thing which is buggy is that the sampled momentum variable are not in `CuArray`.
This PR resolve this issue by making sure position and momentum variable are in the same container by moving momentum variable if needed.

Related issue: Testing against CuArrays #12 


TODOs
- [x] make sure the type constraints works as expected
