### PR TITLE
Fix effective depth

### DIFF
--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -414,7 +414,7 @@ function transition(
     zcand = z0
 
     j = 0
-    while !isterminated(termination) && j <= τ.max_depth
+    while !isterminated(termination) && j < τ.max_depth
         # Sample a direction; `-1` means left and `1` means right
         v = rand(rng, [-1, 1])
         if v == -1


### PR DESCRIPTION
If the current `max_depth` is set to `n` it actually simulates a tree with maximum depth `n+1`. This PR fixes this offset.