### PR TITLE
[WIP] Support of `theta_init` of `Matrix` type / GPU-level multiple chain support #92

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -23,21 +23,26 @@ version = "0.5.6"
 
 [[CSTParser]]
 deps = ["Tokenize"]
-git-tree-sha1 = "0ff80f68f55fcde2ed98d7b24d7abaf20727f3f8"
+git-tree-sha1 = "c69698c3d4a7255bc1b4bc2afc09f59db910243b"
 uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "0.6.1"
+version = "0.6.2"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "84aa74986c5b9b898b0d1acaf3258741ee64754f"
+git-tree-sha1 = "ed2c4abadf84c53d9e58510b5fc48912c2336fbb"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "2.1.0"
+version = "2.2.0"
+
+[[DataAPI]]
+git-tree-sha1 = "674b67f344687a88310213ddfa8a2b3c76cc4252"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.1.0"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "0809951a1774dc724da22d26e4289bbaab77809a"
+git-tree-sha1 = "2103e504f427e54ffa19af9ada225733a21f951f"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.0"
+version = "0.17.3"
 
 [[Dates]]
 deps = ["Printf"]
@@ -52,10 +57,10 @@ deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[FillArrays]]
-deps = ["LinearAlgebra", "Random", "SparseArrays", "Test"]
-git-tree-sha1 = "9ab8f76758cbabba8d7f103c51dce7f73fcf8e92"
+deps = ["LinearAlgebra", "Random", "SparseArrays"]
+git-tree-sha1 = "8fba6ddaf66b45dec830233cea0aae43eb1261ad"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.6.3"
+version = "0.6.4"
 
 [[InplaceOps]]
 deps = ["LinearAlgebra", "Test"]
@@ -97,10 +102,10 @@ deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[Missings]]
-deps = ["SparseArrays", "Test"]
-git-tree-sha1 = "f0719736664b4358aa9ec173077d4285775f8007"
+deps = ["DataAPI"]
+git-tree-sha1 = "de0a5ce9e5289f27df672ffabef4d1e5861247d5"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "0.4.1"
+version = "0.4.3"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
@@ -169,16 +174,16 @@ deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SpecialFunctions]]
-deps = ["BinDeps", "BinaryProvider", "Libdl", "Test"]
-git-tree-sha1 = "0b45dc2e45ed77f445617b99ff2adf0f5b0f23ea"
+deps = ["BinDeps", "BinaryProvider", "Libdl"]
+git-tree-sha1 = "3bdd374b6fd78faf0119b8c5d538788dbf910c6e"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "0.7.2"
+version = "0.8.0"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "db23bbf50064c582b6f2b9b043c8e7e98ea8c0c6"
+git-tree-sha1 = "1085ffbf5fd48fdba64ef8e902ca429c4e1212d3"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "0.11.0"
+version = "0.11.1"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
@@ -201,9 +206,9 @@ deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[Tokenize]]
-git-tree-sha1 = "c8a8b00ae44a94950814ff77850470711a360225"
+git-tree-sha1 = "dfcdbbfb2d0370716c815cbd6f8a364efb6f42cf"
 uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
-version = "0.5.5"
+version = "0.5.6"
 
 [[URIParser]]
 deps = ["Test", "Unicode"]
@@ -217,3 +222,9 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[UnicodePlots]]
+deps = ["Dates", "Random", "SparseArrays", "StatsBase", "Test"]
+git-tree-sha1 = "b8e58d4390ccebfa4f3bf502a45e08066eec3bf9"
+uuid = "b8865327-cd53-5732-bb35-84acbb429228"
+version = "1.1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -24,6 +24,7 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
+UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [targets]
-test = ["Test", "Distributions", "ForwardDiff", "Turing", "Distributed", "DiffResults"]
+test = ["Test", "Distributions", "ForwardDiff", "Turing", "Distributed", "DiffResults", "UnicodePlots"]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ n_samples, n_adapts = 10_000, 2_000
 metric = DiagEuclideanMetric(D)
 h = Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
 int = Leapfrog(find_good_eps(h, θ_init))
-prop = NUTS{Multinomial,GeneralisedNoUTurn}(int)
+prop = NUTS{MultinomialTS,GeneralisedNoUTurn}(int)
 adaptor = StanHMCAdaptor(n_adapts, Preconditioner(metric), NesterovDualAveraging(0.8, int.ϵ))
 
 # Draw samples via simulating Hamiltonian dynamics

--- a/src/AdvancedHMC.jl
+++ b/src/AdvancedHMC.jl
@@ -13,7 +13,7 @@ using ArgCheck: @argcheck
 
 import StatsBase: sample
 
-# Notations	
+# Notations
 # ℓπ: log density of the target distribution
 # ∂ℓπ∂θ: gradient of the log density of the target distribution
 # θ: position variables / model parameters

--- a/src/AdvancedHMC.jl
+++ b/src/AdvancedHMC.jl
@@ -30,7 +30,7 @@ export Hamiltonian
 include("integrator.jl")
 export Leapfrog, JitteredLeapfrog, TemperedLeapfrog
 include("trajectory.jl")
-export StaticTrajectory, find_good_eps, HMCDA, NUTS, Slice, Multinomial, ClassicNoUTurn, GeneralisedNoUTurn
+export StaticTrajectory, find_good_eps, HMCDA, NUTS, SliceTS, MultinomialTS, ClassicNoUTurn, GeneralisedNoUTurn
 
 include("diagnosis.jl")
 include("sampler.jl")

--- a/src/diagnosis.jl
+++ b/src/diagnosis.jl
@@ -1,3 +1,3 @@
-function EBFMI(Es::AbstractVector{<:Real})
-    return sum(i -> (Es[i+1] - Es[i])^2, 1:length(Es)-1) / var(Es)
+function EBFMI(Es::AbstractVector{<:Union{AbstractFloat,AbstractVector{<:AbstractFloat}}})
+    return sum(i -> (Es[i+1] - Es[i]) .^ 2, 1:length(Es)-1) ./ var(Es)
 end

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -8,32 +8,43 @@ struct Hamiltonian{M<:AbstractMetric, Tlogπ, T∂logπ∂θ}
 end
 Base.show(io::IO, h::Hamiltonian) = print(io, "Hamiltonian(metric=$(h.metric))")
 
-
-struct DualValue{Tv<:AbstractFloat, Tg<:AbstractVector{Tv}}
-    value::Tv    # Cached value, e.g. logπ(θ).
-    gradient::Tg # Cached gradient, e.g. ∇logπ(θ).
+struct DualValue{V<:Union{AbstractFloat,AbstractVector{<:AbstractFloat}}, G<:AbstractVecOrMat{<:AbstractFloat}}
+    value::V    # cached value, e.g. logπ(θ)
+    gradient::G # cached gradient, e.g. ∇logπ(θ)
+    function DualValue(value::V, gradient::G) where {V, G}
+        # Check consistence
+        if value isa AbstractFloat
+            # If `value` is a scalar, `gradient` is a vector
+            @assert gradient isa AbstractVector "`typeof(gradient)`: $(typeof(gradient))"
+        else
+            # If `value` is a vector, `gradient` is a matrix
+            @assert gradient isa AbstractMatrix "`typeof(gradient)`: $(typeof(gradient))"
+        end
+        return new{V,G}(value, gradient)
+    end
 end
 
 # `∂H∂θ` now returns `(logprob, -∂ℓπ∂θ)`
-function ∂H∂θ(h::Hamiltonian, θ::AbstractVector)
+function ∂H∂θ(h::Hamiltonian, θ::AbstractVecOrMat)
     res = h.∂ℓπ∂θ(θ)
     return DualValue(res[1], -res[2])
 end
 
-∂H∂r(h::Hamiltonian{<:UnitEuclideanMetric}, r::AbstractVector) = copy(r)
-∂H∂r(h::Hamiltonian{<:DiagEuclideanMetric}, r::AbstractVector) = h.metric.M⁻¹ .* r
-∂H∂r(h::Hamiltonian{<:DenseEuclideanMetric}, r::AbstractVector) = h.metric.M⁻¹ * r
+∂H∂r(h::Hamiltonian{<:UnitEuclideanMetric}, r::AbstractVecOrMat) = copy(r)
+∂H∂r(h::Hamiltonian{<:DiagEuclideanMetric}, r::AbstractVecOrMat) = h.metric.M⁻¹ .* r
+∂H∂r(h::Hamiltonian{<:DenseEuclideanMetric}, r::AbstractVecOrMat) = h.metric.M⁻¹ * r
 
-struct PhasePoint{T<:AbstractVector, V<:DualValue}
+struct PhasePoint{T<:AbstractVecOrMat, V<:DualValue}
     θ::T  # Position variables / model parameters.
     r::T  # Momentum variables
     ℓπ::V # Cached neg potential energy for the current θ.
     ℓκ::V # Cached neg kinect energy for the current r.
-    function PhasePoint(θ::T, r::T, ℓπ::V, ℓκ::V) where {T,V}
+    function PhasePoint(θ::T, r::T, ℓπ::V, ℓκ::V) where {T, V}
         @argcheck length(θ) == length(r) == length(ℓπ.gradient) == length(ℓπ.gradient)
         isfiniteθ, isfiniter, isfiniteℓπ, isfiniteℓκ = isfinite(θ), isfinite(r), isfinite(ℓπ), isfinite(ℓκ)
         if !(isfiniteθ && isfiniter && isfiniteℓπ && isfiniteℓκ)
             @warn "The current proposal will be rejected due to numerical error(s)." isfiniteθ isfiniter isfiniteℓπ isfiniteℓκ
+            # TODO: make `-Inf` adjust to vec or mat
             ℓπ = DualValue(-Inf, ℓπ.gradient)
             ℓκ = DualValue(-Inf, ℓκ.gradient)
         end
@@ -47,7 +58,7 @@ phasepoint(
     r::T;
     ℓπ=∂H∂θ(h, θ),
     ℓκ=DualValue(neg_energy(h, r, θ), ∂H∂r(h, r))
-) where {T<:AbstractVector} = PhasePoint(θ, r, ℓπ, ℓκ)
+) where {T<:AbstractVecOrMat} = PhasePoint(θ, r, ℓπ, ℓκ)
 
 # If position variable and momentum variable are in different containers,
 # move the momentum variable to that of the position variable.
@@ -59,10 +70,10 @@ phasepoint(
     r=T1(_r),
     ℓπ=∂H∂θ(h, θ),
     ℓκ=DualValue(neg_energy(h, r, θ), ∂H∂r(h, r))
-) where {T1<:AbstractVector,T2<:AbstractVector} = PhasePoint(θ, r, ℓπ, ℓκ)
+) where {T1<:AbstractVecOrMat,T2<:AbstractVecOrMat} = PhasePoint(θ, r, ℓπ, ℓκ)
 
 Base.isfinite(v::DualValue) = all(isfinite, v.value) && all(isfinite, v.gradient)
-Base.isfinite(v::AbstractVector) = all(isfinite, v)
+Base.isfinite(v::AbstractVecOrMat) = all(isfinite, v)
 Base.isfinite(z::PhasePoint) = isfinite(z.ℓπ) && isfinite(z.ℓκ)
 
 ###
@@ -72,7 +83,7 @@ Base.isfinite(z::PhasePoint) = isfinite(z.ℓπ) && isfinite(z.ℓκ)
 
 neg_energy(z::PhasePoint) = z.ℓπ.value + z.ℓκ.value
 
-neg_energy(h::Hamiltonian, θ::AbstractVector) = h.ℓπ(θ)
+neg_energy(h::Hamiltonian, θ::AbstractVecOrMat) = h.ℓπ(θ)
 
 neg_energy(
     h::Hamiltonian{<:UnitEuclideanMetric},
@@ -80,11 +91,17 @@ neg_energy(
     θ::T
 ) where {T<:AbstractVector} = -sum(abs2, r) / 2
 
+neg_energy(
+    h::Hamiltonian{<:UnitEuclideanMetric},
+    r::T,
+    θ::T
+) where {T<:AbstractMatrix} = -vec(sum(abs2, r; dims=1)) ./ 2
+
 function neg_energy(
     h::Hamiltonian{<:DiagEuclideanMetric},
     r::T,
     θ::T
-) where {T<:AbstractVector}
+) where {T<:AbstractVecOrMat}
     _r = [abs2(r[i]) * h.metric.M⁻¹[i] for i in 1:length(r)]
     return -sum(_r) / 2
 end
@@ -93,7 +110,7 @@ function neg_energy(
     h::Hamiltonian{<:DenseEuclideanMetric},
     r::T,
     θ::T
-) where {T<:AbstractVector}
+) where {T<:AbstractVecOrMat}
     mul!(h.metric._temp, h.metric.M⁻¹, r)
     return -dot(r, h.metric._temp) / 2
 end
@@ -105,8 +122,8 @@ energy(args...) = -neg_energy(args...)
 ####
 
 phasepoint(
-    rng::AbstractRNG, 
-    θ::AbstractVector{T},
+    rng::AbstractRNG,
+    θ::AbstractVecOrMat{T},
     h::Hamiltonian
 ) where {T<:Real} = phasepoint(h, θ, rand(rng, h.metric))
 

--- a/test/common.jl
+++ b/test/common.jl
@@ -14,16 +14,28 @@ using ForwardDiff: gradient!
 
 ℓπ(θ) = logpdf(MvNormal(zeros(D), ones(D)), θ)
 
-function ∂ℓπ∂θ(θ)
+function ∂ℓπ∂θ(θ::AbstractVector)
     res = GradientResult(θ)
     gradient!(res, ℓπ, θ)
     return (value(res), gradient(res))
 end
 
+function ∂ℓπ∂θ(θ::AbstractMatrix{T}) where {T<:AbstractFloat}
+    v = Vector{T}(undef, size(θ, 2))
+    g = similar(θ)
+    for i in 1:size(θ, 2)
+        res = GradientResult(θ[:,i])
+        gradient!(res, ℓπ, θ[:,i])
+        v[i] = value(res)
+        g[:,i] = gradient(res)
+    end
+    return (v, g)
+end
+
 function ℓπ_gdemo(θ)
     s = exp(θ[1])
     m = θ[2]
-    logprior = logpdf(InverseGamma(2, 3), s) + log(s) + logpdf(Normal(0, sqrt(s)), m) 
+    logprior = logpdf(InverseGamma(2, 3), s) + log(s) + logpdf(Normal(0, sqrt(s)), m)
     loglikelihood = logpdf(Normal(m, sqrt(s)), 1.5) + logpdf(Normal(m, sqrt(s)), 2.0)
     return logprior + loglikelihood
 end

--- a/test/demo.jl
+++ b/test/demo.jl
@@ -26,7 +26,7 @@ n_samples, n_adapts = 10_000, 2_000
 metric = DiagEuclideanMetric(D)
 h = Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
 int = Leapfrog(find_good_eps(h, θ_init))
-prop = NUTS{Multinomial,GeneralisedNoUTurn}(int)
+prop = NUTS{MultinomialTS,GeneralisedNoUTurn}(int)
 adaptor = StanHMCAdaptor(n_adapts, Preconditioner(metric), NesterovDualAveraging(0.8, int.ϵ))
 
 # Draw samples via simulating Hamiltonian dynamics

--- a/test/hmc.jl
+++ b/test/hmc.jl
@@ -27,10 +27,10 @@ n_adapts = 2_000
             @testset "$τsym" for (τsym, τ) in Dict(
                 :HMC => StaticTrajectory(lf, n_steps),
                 :HMCDA => HMCDA(lf, ϵ * n_steps),
-                :(NUTS{Slice,Original}) => NUTS{Slice,ClassicNoUTurn}(lf),
-                :(NUTS{Slice,Generalised}) => NUTS{Slice,GeneralisedNoUTurn}(lf),
-                :(NUTS{Multinomial,Original}) => NUTS{Multinomial,ClassicNoUTurn}(lf),
-                :(NUTS{Multinomial,Generalised}) => NUTS{Multinomial,GeneralisedNoUTurn}(lf),
+                :(NUTS{SliceTS,Original}) => NUTS{SliceTS,ClassicNoUTurn}(lf),
+                :(NUTS{SliceTS,Generalised}) => NUTS{SliceTS,GeneralisedNoUTurn}(lf),
+                :(NUTS{MultinomialTS,Original}) => NUTS{MultinomialTS,ClassicNoUTurn}(lf),
+                :(NUTS{MultinomialTS,Generalised}) => NUTS{MultinomialTS,GeneralisedNoUTurn}(lf),
             )
                 @testset  "NoAdaptation" begin
                     samples, stats = sample(h, τ, θ_init, n_samples; verbose=false, progress=PROGRESS)

--- a/test/hmc_matpara.jl
+++ b/test/hmc_matpara.jl
@@ -1,0 +1,52 @@
+using Test, AdvancedHMC, LinearAlgebra, UnicodePlots
+using Statistics: mean, var, cov
+include("common.jl")
+
+@testset "Matrix parallelisation" begin
+    n_chains_max = 20
+    θ_init = [randn(D, n_chains) for n_chains in 1:n_chains_max]
+    ϵ = 0.1
+    n_steps = 20
+    n_samples = 10_000
+    n_adapts = 2_000
+
+    for metricT in [
+        UnitEuclideanMetric,
+        # DiagEuclideanMetric,
+        # DenseEuclideanMetric
+    ]
+        τ = StaticTrajectory(Leapfrog(ϵ), n_steps)
+
+        time_mat = Vector{Float64}(undef, n_chains_max)
+        for (i, n_chains) in enumerate(1:n_chains_max)
+            h = Hamiltonian(metricT((D, n_chains)), ℓπ, ∂ℓπ∂θ)
+            t = @elapsed samples, stats = sample(h, τ, θ_init[i], n_samples; verbose=false)
+            @test mean(samples) ≈ zeros(D, n_chains) atol=RNDATOL
+            time_mat[i] = t
+        end
+        fig = lineplot(collect(1:n_chains_max), time_mat, title="Scalabiliry of multiple chains", name="matpara", xlabel="Num of chains", ylabel="time (s)")
+
+        # Check time for multiple runs of single chain
+        time_seperate = Vector{Float64}(undef, n_chains_max)
+
+        h_single = Hamiltonian(UnitEuclideanMetric(D), ℓπ, ∂ℓπ∂θ)
+        for (i, n_chains) in enumerate(1:n_chains_max)
+            t = @elapsed for j in 1:n_chains
+                samples, stats = sample(h_single, τ, θ_init[i][:,j], n_samples; verbose=false)
+            end
+            time_seperate[i] = t
+        end
+        lineplot!(fig, collect(1:n_chains_max), time_seperate; color=:blue, name="seperate")
+
+        show(fig); println()
+    end
+
+    # adaptor = StanHMCAdaptor(
+    #     n_adapts,
+    #     Preconditioner(metric),
+    #     NesterovDualAveraging(0.8, τ.integrator.ϵ),
+    # )
+    # samples, stats = sample(h, τ, θ_init, n_samples, adaptor, n_adapts; verbose=false, progress=false)
+
+    # @test mean(samples) ≈ zeros(D) atol=RNDATOL
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using Distributed, Test
         "trajectory",
         "models",
         "hmc",
+        "hmc_matpara",
     ]
 
     res = map(tests) do t

--- a/test/trajectory.jl
+++ b/test/trajectory.jl
@@ -37,9 +37,9 @@ end
 
     ℓu = rand()
     n1 = 2
-    s1 = AdvancedHMC.Slice(z1, ℓu, n1) 
+    s1 = AdvancedHMC.SliceTS(z1, ℓu, n1) 
     n2 = 1
-    s2 = AdvancedHMC.Slice(z2, ℓu, n2) 
+    s2 = AdvancedHMC.SliceTS(z2, ℓu, n2) 
     s3 = AdvancedHMC.combine(rng, s1, s2)
     @test s3.ℓu == ℓu
     @test s3.n == n1 + n2
@@ -52,9 +52,9 @@ end
     @test mean(s3_θ) ≈ ones(D) * n2 / (n1 + n2) rtol=0.01
 
     w1 = 100
-    s1 = AdvancedHMC.Multinomial(z1, log(w1))
+    s1 = AdvancedHMC.MultinomialTS(z1, log(w1))
     w2 = 150
-    s2 = AdvancedHMC.Multinomial(z2, log(w2))
+    s2 = AdvancedHMC.MultinomialTS(z2, log(w2))
     s3 = AdvancedHMC.combine(rng, s1, s2)
     @test s3.ℓw ≈ log(w1 + w2)
 


### PR DESCRIPTION
To address: Support of `theta_init` of `Matrix` type / GPU-level multiple chain support #92

Progress and goal
- [x] `StaticTrajectory`
- [ ] `HMCDA`
- This PR does not aim to support `NUTS`
- [x] `UnitEuclideanMetric`
- [ ] `DiagEuclideanMetric`
- [ ] `DenseEuclideanMetric`
- [ ] `UnitPreconditioner`
- [ ] `DiagPreconditioner`
- [ ] `DensePreconditioner`
- [ ] `NesterovDualAveraging`