### PR TITLE
Add more statistics and move jitter to transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ metric = DiagEuclideanMetric(D)
 h = Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
 int = Leapfrog(find_good_eps(h, θ_init))
 prop = NUTS{MultinomialTS,GeneralisedNoUTurn}(int)
-adaptor = StanHMCAdaptor(n_adapts, Preconditioner(metric), NesterovDualAveraging(0.8, int.ϵ))
+adaptor = StanHMCAdaptor(n_adapts, Preconditioner(metric), NesterovDualAveraging(0.8, int))
 
 # Draw samples via simulating Hamiltonian dynamics
 # - `samples` will store the samples

--- a/src/AdvancedHMC.jl
+++ b/src/AdvancedHMC.jl
@@ -23,7 +23,7 @@ include("adaptation/Adaptation.jl")
 export UnitEuclideanMetric, DiagEuclideanMetric, DenseEuclideanMetric
 export NesterovDualAveraging, Preconditioner, NaiveHMCAdaptor, StanHMCAdaptor
 using .Adaptation
-import .Adaptation: adapt!
+import .Adaptation: adapt!, NesterovDualAveraging
 
 include("hamiltonian.jl")
 export Hamiltonian

--- a/src/adaptation/stepsize.jl
+++ b/src/adaptation/stepsize.jl
@@ -66,6 +66,7 @@ Base.show(io::IO, a::NesterovDualAveraging) = print(io, "NesterovDualAveraging(�
 
 NesterovDualAveraging(γ::T, t_0::T, κ::T, δ::T, ϵ::T) where {T<:AbstractFloat} = NesterovDualAveraging(γ, t_0, κ, δ, DAState(ϵ))
 NesterovDualAveraging(δ::T, ϵ::T) where {T<:AbstractFloat} = NesterovDualAveraging(0.05, 10.0, 0.75, δ, ϵ)
+NesterovDualAveraging(δ::AbstractFloat, i::AbstractIntegrator) = NesterovDualAveraging(δ, nom_step_size(i))
 
 struct ManualSSAdaptor{T<:AbstractFloat} <:StepSizeAdaptor
     state :: MSSState{T}

--- a/src/adaptation/stepsize.jl
+++ b/src/adaptation/stepsize.jl
@@ -66,7 +66,6 @@ Base.show(io::IO, a::NesterovDualAveraging) = print(io, "NesterovDualAveraging(�
 
 NesterovDualAveraging(γ::T, t_0::T, κ::T, δ::T, ϵ::T) where {T<:AbstractFloat} = NesterovDualAveraging(γ, t_0, κ, δ, DAState(ϵ))
 NesterovDualAveraging(δ::T, ϵ::T) where {T<:AbstractFloat} = NesterovDualAveraging(0.05, 10.0, 0.75, δ, ϵ)
-NesterovDualAveraging(δ::AbstractFloat, i::AbstractIntegrator) = NesterovDualAveraging(δ, nom_step_size(i))
 
 struct ManualSSAdaptor{T<:AbstractFloat} <:StepSizeAdaptor
     state :: MSSState{T}

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -67,9 +67,9 @@ Base.show(io::IO, l::Leapfrog) = print(io, "Leapfrog(ϵ=$(round(l.ϵ; sigdigits=
 ### Jittering
 
 mutable struct JitteredLeapfrog{T<:AbstractFloat} <: AbstractLeapfrog{T}
-    ϵ0      ::  T
+    ϵ0      ::  T  # nominal (unjittered) step size
     jitter  ::  T
-    ϵ       ::  T
+    ϵ       ::  T  # current (jittered) step size
 end
 
 JitteredLeapfrog(ϵ0, jitter) = JitteredLeapfrog(ϵ0, jitter, ϵ0)

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -12,7 +12,22 @@ abstract type AbstractIntegrator end
 NesterovDualAveraging(δ::AbstractFloat, i::AbstractIntegrator) = NesterovDualAveraging(δ, nom_step_size(i))
 
 stat(::AbstractIntegrator) = NamedTuple()
+
+"""
+    nom_step_size(::AbstractIntegrator)
+
+Get the nominal integration step size. The current integration step size may
+differ from this, for example if the step size is jittered. Nominal step size is
+usually used in adaptation.
+"""
 nom_step_size(i::AbstractIntegrator) = step_size(i)
+
+"""
+    step_size(::AbstractIntegrator)
+
+Get the current integration step size.
+"""
+function step_size end
 
 abstract type AbstractLeapfrog{T} <: AbstractIntegrator end
 

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -29,7 +29,7 @@ function step(
 ) where {T<:AbstractFloat}
     n_steps = abs(n_steps)  # to support `n_steps < 0` cases
     jitter!(rng, lf)
-    ϵ = fwd ? lf.ϵ : -lf.ϵ
+    ϵ = fwd ? step_size(lf) : -step_size(lf)
 
     @unpack θ, r = z
     @unpack value, gradient = ∂H∂θ(h, θ)

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -5,10 +5,13 @@
 
 abstract type AbstractIntegrator end
 
+stat(::AbstractIntegrator) = NamedTuple()
+
 abstract type AbstractLeapfrog{T} <: AbstractIntegrator end
 
 jitter!(::AbstractRNG, lf::AbstractLeapfrog) = lf
 temper(lf::AbstractLeapfrog, r, ::NamedTuple{(:i, :is_half),Tuple{Int,Bool}}, ::Int) = r
+stat(lf::AbstractLeapfrog) = (step_size_bar=lf.ϵ, step_size=lf.ϵ)
 
 function step(
     rng::AbstractRNG,
@@ -72,6 +75,8 @@ function jitter!(rng::AbstractRNG, lf::JitteredLeapfrog)
     lf.ϵ = lf.ϵ0 * (1 + lf.jitter * (2 * rand(rng) - 1))
     return lf
 end
+
+stat(lf::JitteredLeapfrog) = (step_size_bar=lf.ϵ0, step_size=lf.ϵ)
 
 ### Tempering
 

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -15,7 +15,7 @@ abstract type AbstractLeapfrog{T} <: AbstractIntegrator end
 
 jitter!(::AbstractRNG, lf::AbstractLeapfrog) = lf
 temper(lf::AbstractLeapfrog, r, ::NamedTuple{(:i, :is_half),<:Tuple{Integer,Bool}}, ::Int) = r
-stat(lf::AbstractLeapfrog) = (step_size_bar=lf.ϵ, step_size=lf.ϵ)
+stat(lf::AbstractLeapfrog) = (step_size_bar=lf.ϵ, step_size=lf.ϵ) 
 
 function step(
     rng::AbstractRNG,

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -9,6 +9,8 @@
 
 abstract type AbstractIntegrator end
 
+NesterovDualAveraging(δ::AbstractFloat, i::AbstractIntegrator) = NesterovDualAveraging(δ, nom_step_size(i))
+
 stat(::AbstractIntegrator) = NamedTuple()
 nom_step_size(i::AbstractIntegrator) = step_size(i)
 

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -145,9 +145,10 @@ function sample(
             @info "Finished $n_adapts adapation steps" adaptor τ.integrator h.metric
         end
         # Store sample
-        if !drop_warmup || i > n_adapts
+        is_adapt = i <= n_adapts
+        if !drop_warmup || !is_adapt
             j = i - drop_warmup * n_adapts
-            θs[j], stats[j] = t.z.θ, t.stat
+            θs[j], stats[j] = t.z.θ, merge(t.stat, (is_adapt=is_adapt,))
         end
     end
     # Report end of sampling

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -136,11 +136,12 @@ function sample(
         # Make a step
         t = step(rng, h, τ, t.z)
         # Adapt h and τ; what mutable is the adaptor
-        h, τ, isadapted = adapt!(h, τ, adaptor, i, n_adapts, t.z.θ, t.stat.acceptance_rate)
-        stat = merge(t.stat, (is_adapt=isadapted,))
+        tstat = stat(t)
+        h, τ, isadapted = adapt!(h, τ, adaptor, i, n_adapts, t.z.θ, tstat.acceptance_rate)
+        tstat = merge(tstat, (is_adapt=isadapted,))
         # Update progress meter
         if progress
-            pm_next!(pm, stat, i, h.metric)
+            pm_next!(pm, tstat, i, h.metric)
         # Report finish of adapation
         elseif verbose && isadapted && i == n_adapts
             @info "Finished $n_adapts adapation steps" adaptor τ.integrator h.metric
@@ -148,7 +149,7 @@ function sample(
         # Store sample
         if !drop_warmup || i > n_adapts
             j = i - drop_warmup * n_adapts
-            θs[j], stats[j] = t.z.θ, stat
+            θs[j], stats[j] = t.z.θ, tstat
         end
     end
     # Report end of sampling

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -137,18 +137,18 @@ function sample(
         t = step(rng, h, τ, t.z)
         # Adapt h and τ; what mutable is the adaptor
         h, τ, isadapted = adapt!(h, τ, adaptor, i, n_adapts, t.z.θ, t.stat.acceptance_rate)
+        stat = merge(t.stat, (is_adapt=!isadapted,))
         # Update progress meter
         if progress
-            pm_next!(pm, t.stat, i, h.metric)
+            pm_next!(pm, stat, i, h.metric)
         # Report finish of adapation
         elseif verbose && isadapted && i == n_adapts
             @info "Finished $n_adapts adapation steps" adaptor τ.integrator h.metric
         end
         # Store sample
-        is_adapt = i <= n_adapts
-        if !drop_warmup || !is_adapt
+        if !drop_warmup || i > n_adapts
             j = i - drop_warmup * n_adapts
-            θs[j], stats[j] = t.z.θ, merge(t.stat, (is_adapt=is_adapt,))
+            θs[j], stats[j] = t.z.θ, stat
         end
     end
     # Report end of sampling

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -137,7 +137,7 @@ function sample(
         t = step(rng, h, τ, t.z)
         # Adapt h and τ; what mutable is the adaptor
         h, τ, isadapted = adapt!(h, τ, adaptor, i, n_adapts, t.z.θ, t.stat.acceptance_rate)
-        stat = merge(t.stat, (is_adapt=!isadapted,))
+        stat = merge(t.stat, (is_adapt=isadapted,))
         # Update progress meter
         if progress
             pm_next!(pm, stat, i, h.metric)

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -190,7 +190,7 @@ function transition(
     z::PhasePoint
 ) where {T<:Real}
     # Create the corresponding static τ
-    n_steps = max(1, floor(Int, τ.λ / τ.integrator.ϵ))
+    n_steps = max(1, floor(Int, τ.λ / nom_step_size(τ.integrator)))
     static_τ = StaticTrajectory(τ.integrator, n_steps)
     return transition(rng, static_τ, h, z)
 end

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -161,12 +161,14 @@ function transition(
     end
     H = energy(z)
     tstat = merge(
-        (n_steps=τ.n_steps,
+        (
+         n_steps=τ.n_steps,
          is_accept=is_accept,
          acceptance_rate=α,
          log_density=z.ℓπ.value,
          hamiltonian_energy=H,
-         hamiltonian_energy_error=H - H0),
+         hamiltonian_energy_error=H - H0
+        ),
         stat(τ.integrator)
     )
     return Transition(z, tstat)
@@ -457,7 +459,8 @@ function transition(
 
     H = energy(zcand)
     tstat = merge(
-        (n_steps=tree.nα,
+        (
+         n_steps=tree.nα,
          is_accept=true,
          acceptance_rate=tree.sum_α / tree.nα,
          log_density=zcand.ℓπ.value,
@@ -465,8 +468,9 @@ function transition(
          hamiltonian_energy_error=H - H0,
          max_hamiltonian_energy_error=tree.ΔH_max,
          tree_depth=j,
-         numerical_error=termination.numerical),
-         stat(τ.integrator)
+         numerical_error=termination.numerical,
+        ),
+        stat(τ.integrator)
     )
 
     return Transition(zcand, tstat)

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -160,7 +160,6 @@ function transition(
         z = PhasePoint(z′.θ, -z′.r, z′.ℓπ, z′.ℓκ)
     end
     H = energy(z)
-    istat = stat(τ.integrator)
     tstat = merge(
         (n_steps=τ.n_steps,
          is_accept=is_accept,
@@ -168,7 +167,7 @@ function transition(
          log_density=z.ℓπ.value,
          hamiltonian_energy=H,
          hamiltonian_energy_error=H - H0),
-        istat
+        stat(τ.integrator)
     )
     return Transition(z, tstat)
 end
@@ -457,7 +456,6 @@ function transition(
     end
 
     H = energy(zcand)
-    istat = stat(τ.integrator)
     tstat = merge(
         (n_steps=tree.nα,
          is_accept=true,
@@ -468,7 +466,7 @@ function transition(
          max_hamiltonian_energy_error=tree.ΔH_max,
          tree_depth=j,
          numerical_error=termination.numerical),
-         istat
+         stat(τ.integrator)
     )
 
     return Transition(zcand, tstat)

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -194,8 +194,7 @@ function transition(
 ) where {T<:Real}
     # Create the corresponding static τ
     n_steps = max(1, floor(Int, τ.λ / nom_step_size(τ.integrator)))
-    integrator = jitter(rng, τ.integrator)
-    static_τ = StaticTrajectory(integrator, n_steps)
+    static_τ = StaticTrajectory(τ.integrator, n_steps)
     return transition(rng, static_τ, h, z)
 end
 

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -159,7 +159,7 @@ function transition(
     end
     H = energy(z)
     stat = (
-        step_size=τ.integrator.ϵ,
+        step_size_bar=τ.integrator.ϵ,
         n_steps=τ.n_steps,
         is_accept=is_accept,
         acceptance_rate=α,
@@ -456,7 +456,7 @@ function transition(
     H = energy(zcand)
 
     stat = (
-        step_size=τ.integrator.ϵ,
+        step_size_bar=τ.integrator.ϵ,
         n_steps=tree.nα,
         is_accept=true,
         acceptance_rate=tree.sum_α / tree.nα,

--- a/test/adaptation/precond.jl
+++ b/test/adaptation/precond.jl
@@ -103,7 +103,7 @@ let D=10
         adaptor = StanHMCAdaptor(
             n_adapts, 
             Preconditioner(metric), 
-            NesterovDualAveraging(0.8, prop.integrator.ϵ)
+            NesterovDualAveraging(0.8, prop.integrator)
         )
         samples, stats = sample(h, prop, θ_init, n_samples, adaptor, n_adapts; verbose=false)
         return (samples=samples, stats=stats, adaptor=adaptor)

--- a/test/demo.jl
+++ b/test/demo.jl
@@ -27,7 +27,7 @@ metric = DiagEuclideanMetric(D)
 h = Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
 int = Leapfrog(find_good_eps(h, θ_init))
 prop = NUTS{MultinomialTS,GeneralisedNoUTurn}(int)
-adaptor = StanHMCAdaptor(n_adapts, Preconditioner(metric), NesterovDualAveraging(0.8, int.ϵ))
+adaptor = StanHMCAdaptor(n_adapts, Preconditioner(metric), NesterovDualAveraging(0.8, int))
 
 # Draw samples via simulating Hamiltonian dynamics
 # - `samples` will store the samples

--- a/test/hmc.jl
+++ b/test/hmc.jl
@@ -63,15 +63,15 @@ end
 
                 @testset "$adaptorsym" for (adaptorsym, adaptor) in Dict(
                     :PreconditionerOnly => Preconditioner(metric),
-                    :NesterovDualAveragingOnly => NesterovDualAveraging(0.8, τ.integrator.ϵ),
+                    :NesterovDualAveragingOnly => NesterovDualAveraging(0.8, τ.integrator),
                     :NaiveHMCAdaptor => NaiveHMCAdaptor(
                         Preconditioner(metric),
-                        NesterovDualAveraging(0.8, τ.integrator.ϵ),
+                        NesterovDualAveraging(0.8, τ.integrator),
                     ),
                     :StanHMCAdaptor => StanHMCAdaptor(
                         n_adapts,
                         Preconditioner(metric),
-                        NesterovDualAveraging(0.8, τ.integrator.ϵ),
+                        NesterovDualAveraging(0.8, τ.integrator),
                     ),
                 )
                     # For `Preconditioner`, we use the pre-defined step size as the method cannot adapt the step size.
@@ -93,7 +93,7 @@ end
     adaptor = StanHMCAdaptor(
         n_adapts,
         Preconditioner(metric),
-        NesterovDualAveraging(0.8, τ.integrator.ϵ),
+        NesterovDualAveraging(0.8, τ.integrator),
     )
     samples, stats = sample(h, τ, θ_init, n_samples, adaptor, n_adapts; verbose=false, progress=false, drop_warmup=true)
     @test length(samples) == n_samples - n_adapts

--- a/test/hmc.jl
+++ b/test/hmc.jl
@@ -13,7 +13,7 @@ n_samples = 12_000
 n_adapts = 2_000
 
 function test_stats(::Union{StaticTrajectory,HMCDA}, stats, n_adapts)
-    for name in (:step_size, :step_size_bar, :n_steps, :is_accept, :acceptance_rate, :log_density, :hamiltonian_energy, :hamiltonian_energy_error, :is_adapt)
+    for name in (:step_size, :nom_step_size, :n_steps, :is_accept, :acceptance_rate, :log_density, :hamiltonian_energy, :hamiltonian_energy_error, :is_adapt)
         @test all(map(s -> in(name, propertynames(s)), stats))
     end
     is_adapts = getproperty.(stats, :is_adapt)
@@ -22,7 +22,7 @@ function test_stats(::Union{StaticTrajectory,HMCDA}, stats, n_adapts)
 end
 
 function test_stats(::NUTS, stats, n_adapts)
-    for name in (:step_size, :step_size_bar, :n_steps, :is_accept, :acceptance_rate, :log_density, :hamiltonian_energy, :hamiltonian_energy_error, :is_adapt, :max_hamiltonian_energy_error, :tree_depth, :numerical_error)
+    for name in (:step_size, :nom_step_size, :n_steps, :is_accept, :acceptance_rate, :log_density, :hamiltonian_energy, :hamiltonian_energy_error, :is_adapt, :max_hamiltonian_energy_error, :tree_depth, :numerical_error)
         @test all(map(s -> in(name, propertynames(s)), stats))
     end
     is_adapts = getproperty.(stats, :is_adapt)

--- a/test/hmc.jl
+++ b/test/hmc.jl
@@ -13,7 +13,7 @@ n_samples = 12_000
 n_adapts = 2_000
 
 function test_stats(::Union{StaticTrajectory,HMCDA}, stats, n_adapts)
-    for name in (:step_size_bar, :n_steps, :is_accept, :acceptance_rate, :log_density, :hamiltonian_energy, :hamiltonian_energy_error, :is_adapt)
+    for name in (:step_size, :step_size_bar, :n_steps, :is_accept, :acceptance_rate, :log_density, :hamiltonian_energy, :hamiltonian_energy_error, :is_adapt)
         @test all(map(s -> in(name, propertynames(s)), stats))
     end
     is_adapts = getproperty.(stats, :is_adapt)
@@ -22,7 +22,7 @@ function test_stats(::Union{StaticTrajectory,HMCDA}, stats, n_adapts)
 end
 
 function test_stats(::NUTS, stats, n_adapts)
-    for name in (:step_size_bar, :n_steps, :is_accept, :acceptance_rate, :log_density, :hamiltonian_energy, :hamiltonian_energy_error, :is_adapt, :max_hamiltonian_energy_error, :tree_depth, :numerical_error)
+    for name in (:step_size, :step_size_bar, :n_steps, :is_accept, :acceptance_rate, :log_density, :hamiltonian_energy, :hamiltonian_energy_error, :is_adapt, :max_hamiltonian_energy_error, :tree_depth, :numerical_error)
         @test all(map(s -> in(name, propertynames(s)), stats))
     end
     is_adapts = getproperty.(stats, :is_adapt)

--- a/test/integrator.jl
+++ b/test/integrator.jl
@@ -1,4 +1,4 @@
-using Test, AdvancedHMC
+using Test, Random, AdvancedHMC
 include("common.jl")
 
 ϵ = 0.01
@@ -36,6 +36,17 @@ end
 #     @test θ_Turing ≈ z_AHMC.θ atol=DETATOL
 #     @test r_Turing ≈ z_AHMC.r atol=DETATOL
 # end
+
+@testset "jitter" begin
+    ϵ0 = 0.1
+    lf = JitteredLeapfrog(ϵ0, 0.5)
+    @test lf.ϵ0 == ϵ0
+    @test lf.ϵ == ϵ0
+    
+    lf2 = AdvancedHMC.jitter(Random.GLOBAL_RNG, lf)
+    @test lf2.ϵ0 == ϵ0
+    @test lf2.ϵ != ϵ0
+end
 
 using LinearAlgebra: dot
 using Statistics: mean

--- a/test/models.jl
+++ b/test/models.jl
@@ -14,7 +14,7 @@ include("common.jl")
     h = Hamiltonian(metric, ℓπ_gdemo, ∂ℓπ∂θ_gdemo)
     init_eps = Leapfrog(0.1)
     prop = NUTS(init_eps)
-    adaptor = StanHMCAdaptor(n_adapts, Preconditioner(metric), NesterovDualAveraging(0.8, prop.integrator.ϵ))
+    adaptor = StanHMCAdaptor(n_adapts, Preconditioner(metric), NesterovDualAveraging(0.8, prop.integrator))
 
     samples, _ = sample(rng, h, prop, θ_init, n_samples, adaptor, n_adapts)
 

--- a/test/trajectory.jl
+++ b/test/trajectory.jl
@@ -118,12 +118,18 @@ end
 @testset "BinaryTree" begin
     z = AdvancedHMC.phasepoint(h, θ_init, randn(D))
 
-    t1 = AdvancedHMC.BinaryTree(z, z, ClassicNoUTurn(), 0.1, 1)
-    t2 = AdvancedHMC.BinaryTree(z, z, ClassicNoUTurn(), 1.1, 2)
+    t1 = AdvancedHMC.BinaryTree(z, z, ClassicNoUTurn(), 0.1, 1, -2.0)
+    t2 = AdvancedHMC.BinaryTree(z, z, ClassicNoUTurn(), 1.1, 2, 1.0)
     t3 = AdvancedHMC.combine(t1, t2)
 
     @test t3.sum_α ≈ 1.2 atol=1e-9
     @test t3.nα == 3
+    @test t3.ΔH_max == -2.0
+
+    t4 = AdvancedHMC.BinaryTree(z, z, ClassicNoUTurn(), 1.1, 2, 3.0)
+    t5 = AdvancedHMC.combine(t1, t4)
+
+    @test t5.ΔH_max == 3.0
 end
 
 ### Test ClassicNoUTurn and GeneralisedNoUTurn
@@ -186,16 +192,16 @@ function hand_isturn(z0, z1, rho, v=1)
     return s
 end
 
-ahmc_isturn(z0, z1, rho, v=1) = 
-    AdvancedHMC.isterminated(h, AdvancedHMC.BinaryTree(z0, z1, ClassicNoUTurn(), 0, 0)).dynamic
+ahmc_isturn(z0, z1, rho, v=1) =
+    AdvancedHMC.isterminated(h, AdvancedHMC.BinaryTree(z0, z1, ClassicNoUTurn(), 0, 0, 0.0)).dynamic
 
 function hand_isturn_generalised(z0, z1, rho, v=1)
     s = (dot(rho, -z0.r) >= 0) || (dot(-rho, z1.r) >= 0)
     return s
 end
 
-ahmc_isturn_generalised(z0, z1, rho, v=1) = 
-    AdvancedHMC.isterminated(h, AdvancedHMC.BinaryTree(z0, z1, GeneralisedNoUTurn(rho), 0, 0)).dynamic
+ahmc_isturn_generalised(z0, z1, rho, v=1) =
+    AdvancedHMC.isterminated(h, AdvancedHMC.BinaryTree(z0, z1, GeneralisedNoUTurn(rho), 0, 0, 0.0)).dynamic
 
 @testset "ClassicNoUTurn" begin
     n_tests = 4


### PR DESCRIPTION
See #123 for discussion

Adds the following statistics:
- [x] `hamiltonian_energy_error`
- [x] `max_hamiltonian_energy_error`
- [x] `is_adapt`
- [x] `nom_step_size`

To-do:
- [x] test that stats are returned, in particular that `is_adapt` starts as `true` and switches to `false` after adaptation is over
- [x] refactor code around `jitter` so that the step size used is accessible for stats. I'd appreciate input on this.

I'll submit a PR to Turing so that the new stats fields show up in `internals` instead of `parameters`. Looks like Turing doesn't use AdvancedHMC's `sample` function, so I'll need to add an `is_adapt` over there.