### PR TITLE
Allow more versions for dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedHMC"
 uuid = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
-version = "0.2.10"
+version = "0.2.11"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
@@ -18,10 +18,10 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 julia = "1"
 ArgCheck = "1"
 InplaceOps = "0.3"
-LazyArrays = "0.9,0.12"
-Parameters = "0.10"
+LazyArrays = "0.9, 0.10, 0.11, 0.12, 0.13"
+Parameters = "0.10, 0.11, 0.12"
 ProgressMeter = "1"
-StatsBase = "0.31"
+StatsBase = "0.31, 0.32"
 StatsFuns = "0.8"
 
 [extras]


### PR DESCRIPTION
In particular we need to allow `StatsBase` 0.32 but I think it would be good to loosen the other ones as well.