### PR TITLE
Allow latest version of StatsFuns and prepare for bugfix release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedHMC"
 uuid = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
-version = "0.2.12"
+version = "0.2.13"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
@@ -22,7 +22,7 @@ LazyArrays = "0.9, 0.10, 0.11, 0.12, 0.13"
 Parameters = "0.10, 0.11, 0.12"
 ProgressMeter = "1"
 StatsBase = "0.31, 0.32"
-StatsFuns = "0.8"
+StatsFuns = "0.8, 0.9"
 
 [extras]
 DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,6 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 
 [compat]
-julia = "1"
 ArgCheck = "1"
 InplaceOps = "0.3"
 LazyArrays = "0.9, 0.10, 0.11, 0.12, 0.13"
@@ -23,6 +22,7 @@ Parameters = "0.10, 0.11, 0.12"
 ProgressMeter = "1"
 StatsBase = "0.31, 0.32"
 StatsFuns = "0.8, 0.9"
+julia = "1"
 
 [extras]
 DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"

--- a/test/adaptation/precond.jl
+++ b/test/adaptation/precond.jl
@@ -1,4 +1,4 @@
-using Test, LinearAlgebra, Distributions, AdvancedHMC
+using Test, LinearAlgebra, Distributions, AdvancedHMC, Random
 using AdvancedHMC.Adaptation: WelfordVar, NaiveVar, WelfordCov, NaiveCov, add_sample!, get_var, get_cov, reset!
 using DiffResults: GradientResult, value, gradient
 using ForwardDiff: gradient!
@@ -110,6 +110,7 @@ let D=10
     end
 
     @testset "Adapted mass v.s. true variance" begin
+        Random.seed!(123)
         n_tests = 5
 
         @testset "DiagEuclideanMetric" begin


### PR DESCRIPTION
Because StatsFuns didn't have bound on SpecialFunctions in version 0.8, some users might currently experience breakage if StatsFuns upgrade is hold back.