### PR TITLE
Improve adapt utility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedHMC"
 uuid = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
-version = "0.2.14"
+version = "0.2.15"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ h = Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
 int = Leapfrog(find_good_eps(h, θ_init))
 prop = NUTS{MultinomialTS,GeneralisedNoUTurn}(int)
 adaptor = StanHMCAdaptor(
-    n_adapts, 
     Preconditioner(metric), 
     NesterovDualAveraging(0.8, int)
 )
@@ -98,7 +97,7 @@ where `int` is the integrator used.
 - Preconditioning on metric space `metric`: `pc = Preconditioner(metric)`
 - Nesterov's dual averaging with target acceptance rate `δ` on integrator `int`: `da = NesterovDualAveraging(δ, int)`
 - Combine the two above *naively*: `NaiveHMCAdaptor(pc, da)`
-- Combine the first two using Stan's windowed adaptation: `StanHMCAdaptor(n_adapts, pc, da)` where `n_adapts` is the total number of adaptation steps will be used.
+- Combine the first two using Stan's windowed adaptation: `StanHMCAdaptor(pc, da)` where `n_adapts` is the total number of adaptation steps will be used.
 
 All the combinations are tested in [this file](https://github.com/TuringLang/AdvancedHMC.jl/blob/master/test/hmc.jl) except from using tempered leapfrog integrator together with adaptation, which we found unstable empirically.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ where `int` is the integrator used.
 - Preconditioning on metric space `metric`: `pc = Preconditioner(metric)`
 - Nesterov's dual averaging with target acceptance rate `δ` on integrator `int`: `da = NesterovDualAveraging(δ, int)`
 - Combine the two above *naively*: `NaiveHMCAdaptor(pc, da)`
-- Combine the first two using Stan's windowed adaptation: `StanHMCAdaptor(pc, da)` where `n_adapts` is the total number of adaptation steps will be used.
+- Combine the first two using Stan's windowed adaptation: `StanHMCAdaptor(pc, da)`
 
 All the combinations are tested in [this file](https://github.com/TuringLang/AdvancedHMC.jl/blob/master/test/hmc.jl) except from using tempered leapfrog integrator together with adaptation, which we found unstable empirically.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ If you are interested in using `AdvancedHMC.jl` through a probabilistic programm
 - We presented a poster for AdvancedHMC.jl at [StanCon 2019](https://mc-stan.org/events/stancon2019Cambridge/) in Cambridge, UK. ([pdf](https://github.com/TuringLang/AdvancedHMC.jl/files/3730367/StanCon-AHMC.pdf))
 
 **API CHANGES**
+- [v0.2.15] `n_adapts` is not needed to construct `StanHMCAdaptor`; the old constructor is deprecated.
 - [v0.2.8] Two exported types are renamed: `Multinomial` -> `MultinomialTS` and `Slice` -> `SliceTS`.
 - [v0.2.0] The gradient function passed to `Hamiltonian` is supposed to return a value-gradient tuple now.
 

--- a/src/adaptation/Adaptation.jl
+++ b/src/adaptation/Adaptation.jl
@@ -23,7 +23,7 @@ adapt!(
     α::AbstractScalarOrVec{<:AbstractFloat}
 ) where {T<:AbstractAdaptor} = error("`adapt!(adaptor::$T, θ::AbstractVecOrMat{<:AbstractFloat}, α::AbstractScalarOrVec{<:AbstractFloat})` is not implemented.")
 reset!(adaptor::T) where {T<:AbstractAdaptor} = error("`reset!(adaptor::$T)` is not implemented.")
-init!(adaptor::T, n_adapts::Int) where {T<:AbstractAdaptor} = throw(MethodError(init!, adaptor, n_adapts))
+initialize!(adaptor::T, n_adapts::Int) where {T<:AbstractAdaptor} = throw(MethodError(initialize!, adaptor, n_adapts))
 finalize!(adaptor::T) where {T<:AbstractAdaptor} = error("`finalize!(adaptor::$T)` is not implemented.")
 
 struct NoAdaptation <: AbstractAdaptor end
@@ -58,7 +58,7 @@ function reset!(aca::NaiveHMCAdaptor)
     reset!(aca.ssa)
     reset!(aca.pc)
 end
-init!(adaptor::NaiveHMCAdaptor, n_adapts::Int) = nothing
+initialize!(adaptor::NaiveHMCAdaptor, n_adapts::Int) = nothing
 finalize!(aca::NaiveHMCAdaptor) = finalize!(aca.ssa)
 
 ##
@@ -66,7 +66,7 @@ finalize!(aca::NaiveHMCAdaptor) = finalize!(aca.ssa)
 ##
 include("stan_adaption.jl")
 
-export adapt!, init!, finalize!, getϵ, getM⁻¹, reset!, renew,
+export adapt!, initialize!, finalize!, getϵ, getM⁻¹, reset!, renew,
        NesterovDualAveraging,
        UnitPreconditioner, DiagPreconditioner, DensePreconditioner,
        AbstractMetric, UnitEuclideanMetric, DiagEuclideanMetric, DenseEuclideanMetric,

--- a/src/adaptation/Adaptation.jl
+++ b/src/adaptation/Adaptation.jl
@@ -23,6 +23,7 @@ adapt!(
     α::AbstractScalarOrVec{<:AbstractFloat}
 ) where {T<:AbstractAdaptor} = error("`adapt!(adaptor::$T, θ::AbstractVecOrMat{<:AbstractFloat}, α::AbstractScalarOrVec{<:AbstractFloat})` is not implemented.")
 reset!(adaptor::T) where {T<:AbstractAdaptor} = error("`reset!(adaptor::$T)` is not implemented.")
+init!(adaptor::T, n_adapts::Int) where {T<:AbstractAdaptor} = throw(MethodError(init!, adaptor, n_adapts))
 finalize!(adaptor::T) where {T<:AbstractAdaptor} = error("`finalize!(adaptor::$T)` is not implemented.")
 
 struct NoAdaptation <: AbstractAdaptor end
@@ -57,6 +58,7 @@ function reset!(aca::NaiveHMCAdaptor)
     reset!(aca.ssa)
     reset!(aca.pc)
 end
+init!(adaptor::NaiveHMCAdaptor, n_adapts::Int) = nothing
 finalize!(aca::NaiveHMCAdaptor) = finalize!(aca.ssa)
 
 ##
@@ -64,7 +66,7 @@ finalize!(aca::NaiveHMCAdaptor) = finalize!(aca.ssa)
 ##
 include("stan_adaption.jl")
 
-export adapt!, finalize!, getϵ, getM⁻¹, reset!, renew,
+export adapt!, init!, finalize!, getϵ, getM⁻¹, reset!, renew,
        NesterovDualAveraging,
        UnitPreconditioner, DiagPreconditioner, DensePreconditioner,
        AbstractMetric, UnitEuclideanMetric, DiagEuclideanMetric, DenseEuclideanMetric,

--- a/src/adaptation/precond.jl
+++ b/src/adaptation/precond.jl
@@ -130,7 +130,7 @@ end
 
 abstract type AbstractPreconditioner <: AbstractAdaptor end
 
-init!(adaptor::T, n_adapts::Int) where {T<:AbstractPreconditioner} = nothing
+initialize!(adaptor::T, n_adapts::Int) where {T<:AbstractPreconditioner} = nothing
 finalize!(adaptor::T) where {T<:AbstractPreconditioner} = nothing
 
 ####

--- a/src/adaptation/precond.jl
+++ b/src/adaptation/precond.jl
@@ -130,6 +130,7 @@ end
 
 abstract type AbstractPreconditioner <: AbstractAdaptor end
 
+init!(adaptor::T, n_adapts::Int) where {T<:AbstractPreconditioner} = nothing
 finalize!(adaptor::T) where {T<:AbstractPreconditioner} = nothing
 
 ####

--- a/src/adaptation/precond.jl
+++ b/src/adaptation/precond.jl
@@ -383,8 +383,8 @@ Base.rand(metric::AbstractMetric) = rand(GLOBAL_RNG, metric)
 ####
 
 Preconditioner(m::UnitEuclideanMetric{T}) where {T} = UnitPreconditioner(T)
-Preconditioner(m::DiagEuclideanMetric{T}) where {T} = DiagPreconditioner(T, size(m); var=m.M⁻¹)
-Preconditioner(m::DenseEuclideanMetric{T}) where {T} = DensePreconditioner(T, size(m); covar=m.M⁻¹)
+Preconditioner(m::DiagEuclideanMetric{T}) where {T} = DiagPreconditioner(T, size(m); var=copy(m.M⁻¹))
+Preconditioner(m::DenseEuclideanMetric{T}) where {T} = DensePreconditioner(T, size(m); covar=copy(m.M⁻¹))
 
 Preconditioner(m::Type{TM}, sz::Tuple{Vararg{Int}}=(2,)) where {TM<:AbstractMetric} = Preconditioner(Float64, m, sz)
 Preconditioner(::Type{T}, ::Type{TM}, sz::Tuple{Vararg{Int}}=(2,)) where {T<:AbstractFloat, TM<:AbstractMetric} = Preconditioner(TM(T, sz))

--- a/src/adaptation/stan_adaption.jl
+++ b/src/adaptation/stan_adaption.jl
@@ -12,7 +12,7 @@ end
 StanHMCAdaptorState() = StanHMCAdaptorState(0, 0, 0, Vector{Int}(undef, 0))
 
 # Ref: https://github.com/stan-dev/stan/blob/develop/src/stan/mcmc/windowed_adaptation.hpp
-function init!(state::StanHMCAdaptorState, init_buffer::Int, term_buffer::Int, window_size::Int, n_adapts::Int)
+function initialize!(state::StanHMCAdaptorState, init_buffer::Int, term_buffer::Int, window_size::Int, n_adapts::Int)
     window_start = init_buffer + 1
     window_end = n_adapts - term_buffer
 
@@ -74,8 +74,8 @@ end
 
 getM⁻¹(adaptor::StanHMCAdaptor) = getM⁻¹(adaptor.pc)
 getϵ(adaptor::StanHMCAdaptor)   = getϵ(adaptor.ssa)
-function init!(adaptor::StanHMCAdaptor, n_adapts::Int)
-    init!(adaptor.state, adaptor.init_buffer, adaptor.term_buffer, adaptor.window_size, n_adapts)
+function initialize!(adaptor::StanHMCAdaptor, n_adapts::Int)
+    initialize!(adaptor.state, adaptor.init_buffer, adaptor.term_buffer, adaptor.window_size, n_adapts)
     return adaptor
 end
 finalize!(adaptor::StanHMCAdaptor) = finalize!(adaptor.ssa)
@@ -108,4 +108,4 @@ function adapt!(
 end
 
 # Deprecated constructor
-@deprecate StanHMCAdaptor(n_adapts, pc, ssa) init!(StanHMCAdaptor(pc, ssa), n_adapts)
+@deprecate StanHMCAdaptor(n_adapts, pc, ssa) initialize!(StanHMCAdaptor(pc, ssa), n_adapts)

--- a/src/adaptation/stan_adaption.jl
+++ b/src/adaptation/stan_adaption.jl
@@ -4,9 +4,9 @@
 
 mutable struct StanHMCAdaptorState
     i               ::  Int
-    window_start    ::  Int
-    window_end      ::  Int
-    window_splits   ::  Vector{Int}
+    window_start    ::  Int         # start of mass matrix adaptation
+    window_end      ::  Int         #   end of mass matrix adaptation
+    window_splits   ::  Vector{Int} # iterations to update metric using mass matrix
 end
 
 StanHMCAdaptorState() = StanHMCAdaptorState(0, 0, 0, Vector{Int}(undef, 0))

--- a/src/adaptation/stan_adaption.jl
+++ b/src/adaptation/stan_adaption.jl
@@ -42,26 +42,18 @@ function init!(state::StanHMCAdaptorState, init_buffer::Int, term_buffer::Int, w
     state.window = window
 end
 
-function get_win_starts_ends(window)
-    winstarts, winends = [], []
-    for i in 1:length(window)-1
-        if window[i] != winin && is_in_window(window[i+1])
-            push!(winstarts, i)
-        end
-        if is_window_end(window[i])
-            push!(winends, i)
-        end
-    end
-    return winstarts, winends
-end
-
-function Base.show(io::IO, state::StanHMCAdaptorState)
+function getwindows(state)
     window = state.window
     windows = length(window) > 0 ? (
         findfirst(ws -> ws == winin, window) - 1, 
         findall(ws -> ws == winend, state.window)...,
         (state.window[end] == winin ? tuple(length(state.window)) : tuple())...
     ) : tuple()
+    return windows
+end
+
+function Base.show(io::IO, state::StanHMCAdaptorState)
+    windows = getwindows(state)
     print(io, "windows(" * string(join(windows, ", ")) * ")")
 end
 

--- a/src/adaptation/stan_adaption.jl
+++ b/src/adaptation/stan_adaption.jl
@@ -60,7 +60,6 @@ end
 ### Adaptors ###
 ################
 
-# TODO: currently only StanHMCAdaptor has the filed `n_adapts`. maybe we could unify all
 # Acknowledgement: this adaption settings is mimicing Stan's 3-phase adaptation.
 struct StanHMCAdaptor{M<:AbstractPreconditioner, Tssa<:StepSizeAdaptor} <: AbstractAdaptor
     pc          :: M
@@ -72,7 +71,6 @@ struct StanHMCAdaptor{M<:AbstractPreconditioner, Tssa<:StepSizeAdaptor} <: Abstr
 end
 Base.show(io::IO, a::StanHMCAdaptor) =
     print(io, "StanHMCAdaptor(\n    pc=$(a.pc),\n    ssa=$(a.ssa),\n    init_buffer=$(a.init_buffer),\n    term_buffer=$(a.term_buffer),\n    window_size=$(a.window_size),\n    state=$(a.state)\n)")
-
 
 function StanHMCAdaptor(
     pc::M,
@@ -114,3 +112,20 @@ function adapt!(
         reset!(tp.pc)
     end
 end
+
+# Deprecated constructor
+
+function StanHMCAdaptor(
+    n_adapts::Int,
+    pc::M,
+    ssa::StepSizeAdaptor;
+    init_buffer::Int=75,
+    term_buffer::Int=50,
+    window_size::Int=25
+) where {M<:AbstractPreconditioner}
+    adaptor = StanHMCAdaptor(pc, ssa, init_buffer, term_buffer, window_size, StanHMCAdaptorState(Vector{WindowState}(undef, 0)))
+    init!(adaptor)
+    return adaptor
+end
+
+@deprecate StanHMCAdaptor(n_adapts, pc, ssa) StanHMCAdaptor(pc, ssa)

--- a/src/adaptation/stan_adaption.jl
+++ b/src/adaptation/stan_adaption.jl
@@ -4,6 +4,7 @@
 
 mutable struct StanHMCAdaptorState
     i           :: Int
+    n_adapts    :: Int
     window_size :: Int
     next_window :: Int
 end
@@ -15,7 +16,6 @@ end
 # TODO: currently only StanHMCAdaptor has the filed `n_adapts`. maybe we could unify all
 # Acknowledgement: this adaption settings is mimicing Stan's 3-phase adaptation.
 struct StanHMCAdaptor{M<:AbstractPreconditioner, Tssa<:StepSizeAdaptor} <: AbstractAdaptor
-    n_adapts    :: Int
     pc          :: M
     ssa         :: Tssa
     init_buffer :: Int
@@ -23,10 +23,9 @@ struct StanHMCAdaptor{M<:AbstractPreconditioner, Tssa<:StepSizeAdaptor} <: Abstr
     state       :: StanHMCAdaptorState
 end
 Base.show(io::IO, a::StanHMCAdaptor) =
-    print(io, "StanHMCAdaptor(n_adapts=$(a.n_adapts), pc=$(a.pc), ssa=$(a.ssa), init_buffer=$(a.init_buffer), term_buffer=$(a.term_buffer))")
+    print(io, "StanHMCAdaptor(pc=$(a.pc), ssa=$(a.ssa), init_buffer=$(a.init_buffer), term_buffer=$(a.term_buffer))")
 
 function StanHMCAdaptor(
-    n_adapts::Int,
     pc::M,
     ssa::StepSizeAdaptor,
     init_buffer::Int=75,
@@ -34,29 +33,29 @@ function StanHMCAdaptor(
     window_size::Int=25
 ) where {M<:AbstractPreconditioner}
     next_window = init_buffer + window_size - 1
-    return StanHMCAdaptor(n_adapts, pc, ssa, init_buffer, term_buffer, StanHMCAdaptorState(0, window_size, next_window))
+    return StanHMCAdaptor(pc, ssa, init_buffer, term_buffer, StanHMCAdaptorState(0, 0, window_size, next_window))
 end
 
 # Ref: https://github.com/stan-dev/stan/blob/develop/src/stan/mcmc/windowed_adaptation.hpp
 function is_in_window(tp::StanHMCAdaptor)
     return (tp.state.i >= tp.init_buffer) &&
-           (tp.state.i < tp.n_adapts - tp.term_buffer) &&
-           (tp.state.i != tp.n_adapts)
+           (tp.state.i < tp.state.n_adapts - tp.term_buffer) &&
+           (tp.state.i != tp.state.n_adapts)
 end
 
 function is_window_end(tp::StanHMCAdaptor)
     return (tp.state.i == tp.state.next_window) &&
-           (tp.state.i != tp.n_adapts)
+           (tp.state.i != tp.state.n_adapts)
 end
 
 function compute_next_window!(tp::StanHMCAdaptor)
-    if ~(tp.state.next_window == tp.n_adapts - tp.term_buffer - 1)
+    if ~(tp.state.next_window == tp.state.n_adapts - tp.term_buffer - 1)
         tp.state.window_size *= 2
         tp.state.next_window = tp.state.i + tp.state.window_size
-        if ~(tp.state.next_window == tp.n_adapts - tp.term_buffer - 1)
+        if ~(tp.state.next_window == tp.state.n_adapts - tp.term_buffer - 1)
             next_window_boundary = tp.state.next_window + 2 * tp.state.window_size
-            if (next_window_boundary >= tp.n_adapts - tp.term_buffer)
-                tp.state.next_window = tp.n_adapts - tp.term_buffer - 1
+            if (next_window_boundary >= tp.state.n_adapts - tp.term_buffer)
+                tp.state.next_window = tp.state.n_adapts - tp.term_buffer - 1
             end
         end
     end
@@ -64,6 +63,9 @@ end
 
 getM⁻¹(adaptor::StanHMCAdaptor) = getM⁻¹(adaptor.pc)
 getϵ(adaptor::StanHMCAdaptor)   = getϵ(adaptor.ssa)
+function init!(adaptor::StanHMCAdaptor, n_adapts::Int)
+    adaptor.state.n_adapts = n_adapts
+end
 finalize!(adaptor::StanHMCAdaptor) = finalize!(adaptor.ssa)
 # reset!(adaptor::StanHMCAdaptor) # Not used.
 

--- a/src/adaptation/stan_adaption.jl
+++ b/src/adaptation/stan_adaption.jl
@@ -86,6 +86,7 @@ getM⁻¹(adaptor::StanHMCAdaptor) = getM⁻¹(adaptor.pc)
 getϵ(adaptor::StanHMCAdaptor)   = getϵ(adaptor.ssa)
 function init!(adaptor::StanHMCAdaptor, n_adapts::Int)
     init!(adaptor.state, adaptor.init_buffer, adaptor.term_buffer, adaptor.window_size, n_adapts)
+    return adaptor
 end
 finalize!(adaptor::StanHMCAdaptor) = finalize!(adaptor.ssa)
 
@@ -114,18 +115,4 @@ function adapt!(
 end
 
 # Deprecated constructor
-
-function StanHMCAdaptor(
-    n_adapts::Int,
-    pc::M,
-    ssa::StepSizeAdaptor;
-    init_buffer::Int=75,
-    term_buffer::Int=50,
-    window_size::Int=25
-) where {M<:AbstractPreconditioner}
-    adaptor = StanHMCAdaptor(pc, ssa, init_buffer, term_buffer, window_size, StanHMCAdaptorState(Vector{WindowState}(undef, 0)))
-    init!(adaptor)
-    return adaptor
-end
-
-@deprecate StanHMCAdaptor(n_adapts, pc, ssa) StanHMCAdaptor(pc, ssa)
+@deprecate StanHMCAdaptor(n_adapts, pc, ssa) init!(StanHMCAdaptor(pc, ssa), n_adapts)

--- a/src/adaptation/stan_adaption.jl
+++ b/src/adaptation/stan_adaption.jl
@@ -14,8 +14,7 @@ end
 # Ref: https://github.com/stan-dev/stan/blob/develop/src/stan/mcmc/windowed_adaptation.hpp
 function init!(state::StanHMCAdaptorState, init_buffer::Int, term_buffer::Int, window_size::Int, n_adapts::Int)
     # Init by all out-window points  
-    window = Vector{WindowState}(undef, n_adapts)
-    window .= winout
+    window = fill(winout, n_adapts)
 
     # Update in-window points
     window[init_buffer+1:end-term_buffer] .= winin

--- a/src/adaptation/stan_adaption.jl
+++ b/src/adaptation/stan_adaption.jl
@@ -15,7 +15,7 @@ StanHMCAdaptorState() = StanHMCAdaptorState(0, 0, 0, Vector{Int}(undef, 0))
 function init!(state::StanHMCAdaptorState, init_buffer::Int, term_buffer::Int, window_size::Int, n_adapts::Int)
     window_start = init_buffer + 1
     window_end = n_adapts - term_buffer
-    
+
     # Update window-end points
     window_splits = Vector{Int}(undef, 0)
     next_window = init_buffer + window_size
@@ -60,7 +60,7 @@ struct StanHMCAdaptor{M<:AbstractPreconditioner, Tssa<:StepSizeAdaptor} <: Abstr
     state       :: StanHMCAdaptorState
 end
 Base.show(io::IO, a::StanHMCAdaptor) =
-    print(io, "StanHMCAdaptor(\n    pc=$(a.pc),\n    ssa=$(a.ssa),\n    init_buffer=$(a.init_buffer), term_buffer=$(a.term_buffer), indow_size=$(a.window_size),\n    state=$(a.state)\n)")
+    print(io, "StanHMCAdaptor(\n    pc=$(a.pc),\n    ssa=$(a.ssa),\n    init_buffer=$(a.init_buffer), term_buffer=$(a.term_buffer), window_size=$(a.window_size),\n    state=$(a.state)\n)")
 
 function StanHMCAdaptor(
     pc::M,

--- a/src/adaptation/stan_adaption.jl
+++ b/src/adaptation/stan_adaption.jl
@@ -17,7 +17,8 @@ function init!(state::StanHMCAdaptorState, init_buffer::Int, term_buffer::Int, w
     window = fill(winout, n_adapts)
 
     # Update in-window points
-    window[init_buffer+1:end-term_buffer] .= winin
+    foreach(i -> window[i] = winin, init_buffer+1:n_adapts-term_buffer)
+    # window[init_buffer+1:end-term_buffer] .= winin    # this is buggy for Julia 1.0 and 1.1
 
     # Update window-end points
     next_window = init_buffer + window_size

--- a/src/adaptation/stepsize.jl
+++ b/src/adaptation/stepsize.jl
@@ -140,6 +140,8 @@ adapt!(
 
 reset!(da::NesterovDualAveraging) = reset!(da.state)
 
+init!(adaptor::NesterovDualAveraging, n_adapts::Int) = nothing
+
 function finalize!(da::NesterovDualAveraging)
     da.state.ϵ = exp.(da.state.x_bar)
 end

--- a/src/adaptation/stepsize.jl
+++ b/src/adaptation/stepsize.jl
@@ -140,7 +140,7 @@ adapt!(
 
 reset!(da::NesterovDualAveraging) = reset!(da.state)
 
-init!(adaptor::NesterovDualAveraging, n_adapts::Int) = nothing
+initialize!(adaptor::NesterovDualAveraging, n_adapts::Int) = nothing
 
 function finalize!(da::NesterovDualAveraging)
     da.state.ϵ = exp.(da.state.x_bar)

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -48,7 +48,7 @@ function adapt!(
 )
     isadapted = false
     if i <= n_adapts
-        i == 1 && init!(adaptor, n_adapts)
+        i == 1 && initialize!(adaptor, n_adapts)
         adapt!(adaptor, θ, α)
         i == n_adapts && finalize!(adaptor)
         h, τ = update(h, τ, adaptor)

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -48,6 +48,7 @@ function adapt!(
 )
     isadapted = false
     if i <= n_adapts
+        i == 1 && init!(adaptor, n_adapts)
         adapt!(adaptor, θ, α)
         i == n_adapts && finalize!(adaptor)
         h, τ = update(h, τ, adaptor)
@@ -138,7 +139,7 @@ function sample(
 ) where {T<:AbstractVecOrMat{<:AbstractFloat}}
     @assert !(drop_warmup && (adaptor isa Adaptation.NoAdaptation)) "Cannot drop warmup samples if there is no adaptation phase."
     # Prepare containers to store sampling results
-    n_keep = n_samples - drop_warmup ? n_adapts : 0
+    n_keep = n_samples - (drop_warmup ? n_adapts : 0)
     θs, stats = Vector{T}(undef, n_keep), Vector{NamedTuple}(undef, n_keep)
     # Initial sampling
     h, t = sample_init(rng, h, θ)

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -138,7 +138,7 @@ function sample(
 ) where {T<:AbstractVecOrMat{<:AbstractFloat}}
     @assert !(drop_warmup && (adaptor isa Adaptation.NoAdaptation)) "Cannot drop warmup samples if there is no adaptation phase."
     # Prepare containers to store sampling results
-    n_keep = n_samples - drop_warmup * n_adapts
+    n_keep = n_samples - drop_warmup ? n_adapts : 0
     θs, stats = Vector{T}(undef, n_keep), Vector{NamedTuple}(undef, n_keep)
     # Initial sampling
     h, t = sample_init(rng, h, θ)

--- a/test/adaptation/precond.jl
+++ b/test/adaptation/precond.jl
@@ -60,24 +60,21 @@ end
     θ = [0.0, 0.0, 0.0, 0.0]
 
     adaptor1 = StanHMCAdaptor(
-        1000,
         Preconditioner(UnitEuclideanMetric),
         NesterovDualAveraging(0.8, 0.5)
     )
     adaptor2 = StanHMCAdaptor(
-        1000,
         Preconditioner(DiagEuclideanMetric),
         NesterovDualAveraging(0.8, 0.5)
     )
     adaptor3 = StanHMCAdaptor(
-        1000,
         Preconditioner(DenseEuclideanMetric),
         NesterovDualAveraging(0.8, 0.5)
     )
-
-    AdvancedHMC.adapt!(adaptor1, θ, 1.)
-    AdvancedHMC.adapt!(adaptor2, θ, 1.)
-    AdvancedHMC.adapt!(adaptor3, θ, 1.)
+    for a in [adaptor1, adaptor2, adaptor3]
+        AdvancedHMC.init!(a, 1_000)
+        AdvancedHMC.adapt!(a, θ, 1.)
+    end
     @test AdvancedHMC.Adaptation.getM⁻¹(adaptor2) == ones(length(θ))
     @test AdvancedHMC.Adaptation.getM⁻¹(adaptor3) == LinearAlgebra.diagm(0 => ones(length(θ)))
 end
@@ -103,7 +100,6 @@ let D=10
         h = Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
         prop = NUTS(Leapfrog(find_good_eps(h, θ_init)))
         adaptor = StanHMCAdaptor(
-            n_adapts, 
             Preconditioner(metric),
             NesterovDualAveraging(0.8, prop.integrator)
         )

--- a/test/adaptation/precond.jl
+++ b/test/adaptation/precond.jl
@@ -73,7 +73,7 @@ end
     )
     for a in [adaptor1, adaptor2, adaptor3]
         AdvancedHMC.init!(a, 1_000)
-        @test a.state.window_start == 75
+        @test a.state.window_start == 76
         @test a.state.window_end == 950
         @test a.state.window_splits == [100, 150, 250, 450, 950]
         AdvancedHMC.adapt!(a, θ, 1.)
@@ -117,7 +117,7 @@ let D=10
     end
 
     @testset "Adapted mass v.s. true variance" begin
-        Random.seed!(123)
+        Random.seed!(1)
         n_tests = 5
 
         @testset "DiagEuclideanMetric" begin
@@ -133,7 +133,7 @@ let D=10
                 @test res.adaptor.pc.var ≈ σ .^ 2 rtol=0.2
 
                 res = runnuts(ℓπ, ∂ℓπ∂θ, DenseEuclideanMetric(D))
-                @test res.adaptor.pc.covar ≈ diagm(0 => σ.^2) rtol=0.25
+                @test res.adaptor.pc.covar ≈ diagm(0 => σ .^ 2) rtol=0.25
             end
         end
 

--- a/test/adaptation/precond.jl
+++ b/test/adaptation/precond.jl
@@ -95,7 +95,7 @@ let D=10
     function runnuts(ℓπ, ∂ℓπ∂θ, metric; n_samples=2_000)
         n_adapts = 1_000
 
-        θ_init = randn(D)
+        θ_init = rand(D)
 
         h = Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
         prop = NUTS(Leapfrog(find_good_eps(h, θ_init)))

--- a/test/adaptation/precond.jl
+++ b/test/adaptation/precond.jl
@@ -117,11 +117,12 @@ let D=10
     end
 
     @testset "Adapted mass v.s. true variance" begin
-        Random.seed!(1)
         n_tests = 5
 
         @testset "DiagEuclideanMetric" begin
             for _ in 1:n_tests
+                Random.seed!(1)
+                
                 # Random variance
                 σ = ones(D) + abs.(randn(D))
 

--- a/test/adaptation/precond.jl
+++ b/test/adaptation/precond.jl
@@ -81,7 +81,7 @@ end
 
     @test_deprecated StanHMCAdaptor(
         1_000,
-        Preconditioner(DenseEuclideanMetric),
+        Preconditioner(DiagEuclideanMetric),
         NesterovDualAveraging(0.8, 0.5)
     )
 end

--- a/test/adaptation/precond.jl
+++ b/test/adaptation/precond.jl
@@ -73,7 +73,9 @@ end
     )
     for a in [adaptor1, adaptor2, adaptor3]
         AdvancedHMC.init!(a, 1_000)
-        @test AdvancedHMC.Adaptation.getwindows(a.state) == (75, 100, 150, 250, 450, 950)
+        @test a.state.window_start == 75
+        @test a.state.window_end == 950
+        @test a.state.window_splits == [100, 150, 250, 450, 950]
         AdvancedHMC.adapt!(a, θ, 1.)
     end
     @test AdvancedHMC.Adaptation.getM⁻¹(adaptor2) == ones(length(θ))

--- a/test/adaptation/precond.jl
+++ b/test/adaptation/precond.jl
@@ -78,6 +78,12 @@ end
     end
     @test AdvancedHMC.Adaptation.getM⁻¹(adaptor2) == ones(length(θ))
     @test AdvancedHMC.Adaptation.getM⁻¹(adaptor3) == LinearAlgebra.diagm(0 => ones(length(θ)))
+
+    @test_deprecated StanHMCAdaptor(
+        1_000,
+        Preconditioner(DenseEuclideanMetric),
+        NesterovDualAveraging(0.8, 0.5)
+    )
 end
 
 let D=10

--- a/test/adaptation/precond.jl
+++ b/test/adaptation/precond.jl
@@ -73,6 +73,7 @@ end
     )
     for a in [adaptor1, adaptor2, adaptor3]
         AdvancedHMC.init!(a, 1_000)
+        @test AdvancedHMC.Adaptation.getwindows(a.state) == (75, 100, 150, 250, 450, 950)
         AdvancedHMC.adapt!(a, θ, 1.)
     end
     @test AdvancedHMC.Adaptation.getM⁻¹(adaptor2) == ones(length(θ))

--- a/test/adaptation/precond.jl
+++ b/test/adaptation/precond.jl
@@ -72,7 +72,7 @@ end
         NesterovDualAveraging(0.8, 0.5)
     )
     for a in [adaptor1, adaptor2, adaptor3]
-        AdvancedHMC.init!(a, 1_000)
+        AdvancedHMC.initialize!(a, 1_000)
         @test a.state.window_start == 76
         @test a.state.window_end == 950
         @test a.state.window_splits == [100, 150, 250, 450, 950]
@@ -122,7 +122,7 @@ let D=10
         @testset "DiagEuclideanMetric" begin
             for _ in 1:n_tests
                 Random.seed!(1)
-                
+
                 # Random variance
                 σ = ones(D) + abs.(randn(D))
 

--- a/test/demo.jl
+++ b/test/demo.jl
@@ -17,7 +17,7 @@ end
 using AdvancedHMC
 
 # Sampling parameter settings
-n_samples, n_adapts = 10_000, 2_000
+n_samples, n_adapts = 12_000, 2_000
 
 # Draw a random starting points
 θ_init = rand(D)

--- a/test/demo.jl
+++ b/test/demo.jl
@@ -28,7 +28,6 @@ h = Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
 int = Leapfrog(find_good_eps(h, θ_init))
 prop = NUTS{MultinomialTS,GeneralisedNoUTurn}(int)
 adaptor = StanHMCAdaptor(
-    n_adapts, 
     Preconditioner(metric), 
     NesterovDualAveraging(0.8, int)
 )

--- a/test/hmc.jl
+++ b/test/hmc.jl
@@ -7,7 +7,7 @@ using Statistics: mean, var, cov
 include("common.jl")
 
 θ_init = rand(D)
-ϵ = 0.5
+ϵ = 0.2
 n_steps = 20
 n_samples = 12_000
 n_adapts = 2_000

--- a/test/hmc.jl
+++ b/test/hmc.jl
@@ -7,7 +7,7 @@ using Statistics: mean, var, cov
 include("common.jl")
 
 θ_init = rand(D)
-ϵ = 0.1
+ϵ = 0.5
 n_steps = 20
 n_samples = 12_000
 n_adapts = 2_000

--- a/test/hmc.jl
+++ b/test/hmc.jl
@@ -71,7 +71,6 @@ end
                         NesterovDualAveraging(0.8, τ.integrator),
                     ),
                     :StanHMCAdaptor => StanHMCAdaptor(
-                        n_adapts,
                         Preconditioner(metric),
                         NesterovDualAveraging(0.8, τ.integrator),
                     ),
@@ -93,7 +92,6 @@ end
     h = Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
     τ = NUTS(Leapfrog(ϵ))
     adaptor = StanHMCAdaptor(
-        n_adapts,
         Preconditioner(metric),
         NesterovDualAveraging(0.8, τ.integrator),
     )

--- a/test/hmc.jl
+++ b/test/hmc.jl
@@ -8,7 +8,7 @@ include("common.jl")
 
 θ_init = rand(D)
 ϵ = 0.2
-n_steps = 20
+n_steps = 10
 n_samples = 12_000
 n_adapts = 2_000
 

--- a/test/hmc.jl
+++ b/test/hmc.jl
@@ -6,7 +6,7 @@ using Parameters: reconstruct
 using Statistics: mean, var, cov
 include("common.jl")
 
-θ_init = rand(D)
+θ_init = rand(MersenneTwister(1), D)
 ϵ = 0.2
 n_steps = 10
 n_samples = 12_000
@@ -31,8 +31,6 @@ function test_stats(::NUTS, stats, n_adapts)
 end
 
 @testset "HMC and NUTS" begin
-    Random.seed!(1)
-
     @testset "$metricsym" for (metricsym, metric) in Dict(
         :UnitEuclideanMetric => UnitEuclideanMetric(D),
         :DiagEuclideanMetric => DiagEuclideanMetric(D),
@@ -53,6 +51,7 @@ end
                 :(NUTS{MultinomialTS,Generalised}) => NUTS{MultinomialTS,GeneralisedNoUTurn}(lf),
             )
                 @testset  "NoAdaptation" begin
+                    Random.seed!(1)
                     samples, stats = sample(h, τ, θ_init, n_samples; verbose=false, progress=PROGRESS)
                     @test mean(samples[n_adapts+1:end]) ≈ zeros(D) atol=RNDATOL
                 end
@@ -75,11 +74,12 @@ end
                         NesterovDualAveraging(0.8, τ.integrator),
                     ),
                 )
+                    Random.seed!(1)
                     # For `Preconditioner`, we use the pre-defined step size as the method cannot adapt the step size.
                     # For other adapatation methods that are able to adpat the step size, we use `find_good_eps`.
                     τ_used = adaptorsym == :PreconditionerOnly ? τ : reconstruct(τ, integrator=reconstruct(lf, ϵ=find_good_eps(h, θ_init)))
-                    samples, stats = sample(h, τ_used , θ_init, n_samples, adaptor, n_adapts; verbose=false, progress=PROGRESS, drop_warmup=false)
-                    @test mean(samples[(n_adapts + 1):end]) ≈ zeros(D) atol=RNDATOL
+                    samples, stats = sample(h, τ_used , θ_init, n_samples, adaptor, n_adapts; verbose=false, progress=PROGRESS)
+                    @test mean(samples) ≈ zeros(D) atol=RNDATOL
                     test_stats(τ_used, stats, n_adapts)
                 end
             end

--- a/test/hmc.jl
+++ b/test/hmc.jl
@@ -31,7 +31,7 @@ function test_stats(::NUTS, stats, n_adapts)
 end
 
 @testset "HMC and NUTS" begin
-    Random.seed!(123)
+    Random.seed!(1)
 
     @testset "$metricsym" for (metricsym, metric) in Dict(
         :UnitEuclideanMetric => UnitEuclideanMetric(D),

--- a/test/hmc_mat.jl
+++ b/test/hmc_mat.jl
@@ -6,7 +6,7 @@ include("common.jl")
     n_chains_max = 20
     n_chains_list = collect(1:n_chains_max)
     θ_init_list = [rand(D, n_chains) for n_chains in n_chains_list]
-    ϵ = 0.5
+    ϵ = 0.2
     lf = Leapfrog(ϵ)
     i_test = 5
     lfi = Leapfrog(fill(ϵ, i_test))

--- a/test/hmc_mat.jl
+++ b/test/hmc_mat.jl
@@ -6,7 +6,7 @@ include("common.jl")
     n_chains_max = 20
     n_chains_list = collect(1:n_chains_max)
     θ_init_list = [rand(D, n_chains) for n_chains in n_chains_list]
-    ϵ = 0.1
+    ϵ = 0.5
     lf = Leapfrog(ϵ)
     i_test = 5
     lfi = Leapfrog(fill(ϵ, i_test))

--- a/test/hmc_mat.jl
+++ b/test/hmc_mat.jl
@@ -39,7 +39,6 @@ include("common.jl")
                 NesterovDualAveraging(0.8, lfi.ϵ),
             ),
             StanHMCAdaptor(
-                n_adapts,
                 Preconditioner(metric),
                 NesterovDualAveraging(0.8, lfi.ϵ),
             ),

--- a/test/hmc_mat.jl
+++ b/test/hmc_mat.jl
@@ -11,7 +11,7 @@ include("common.jl")
     i_test = 5
     lfi = Leapfrog(fill(ϵ, i_test))
     lfi_jittered = JitteredLeapfrog(fill(ϵ, i_test), 1.0)
-    n_steps = 20
+    n_steps = 10
     n_samples = 12_000
     n_adapts = 2_000
 

--- a/test/models.jl
+++ b/test/models.jl
@@ -14,7 +14,7 @@ include("common.jl")
     h = Hamiltonian(metric, ℓπ_gdemo, ∂ℓπ∂θ_gdemo)
     init_eps = Leapfrog(0.1)
     prop = NUTS(init_eps)
-    adaptor = StanHMCAdaptor(n_adapts, Preconditioner(metric), NesterovDualAveraging(0.8, prop.integrator))
+    adaptor = StanHMCAdaptor(Preconditioner(metric), NesterovDualAveraging(0.8, prop.integrator))
 
     samples, _ = sample(rng, h, prop, θ_init, n_samples, adaptor, n_adapts)
 


### PR DESCRIPTION
Resolves
- https://github.com/TuringLang/AdvancedHMC.jl/issues/112
- https://github.com/TuringLang/AdvancedHMC.jl/issues/97
- Bugfix: All windows in `StanHMCAdaptor` had an offset of `1`

Changes:
- We no longer pass `n_adapts` when creating `StanHMCAdaptor`.
- The default `show` for `StanHMCAdaptor` looks like below.

```julia
StanHMCAdaptor(
    pc=DiagPreconditioner,
    ssa=NesterovDualAveraging(γ=0.05, t_0=10.0, κ=0.75, δ=0.8, state.ϵ=0.1),
    init_buffer=75,
    term_buffer=50,
    window_size=25,
    state=windows(75, 100, 150, 250, 450, 850, 1950)
)
```

Note that the windows are printed.