### PR TITLE
Add DifferentialEquations.jl integrators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -35,6 +35,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 Bijectors = "76274a88-744f-5084-9051-94815aaf08c4"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 
 [targets]
-test = ["Test", "Distributions", "ForwardDiff", "Turing", "Distributed", "DiffResults", "UnicodePlots", "Bijectors"]
+test = ["Test", "Distributions", "ForwardDiff", "Turing", "Distributed", "DiffResults", "UnicodePlots", "Bijectors", "OrdinaryDiffEq"]

--- a/src/init.jl
+++ b/src/init.jl
@@ -5,11 +5,11 @@ function __init__()
 
         struct DiffEqIntegrator{T<:AbstractScalarOrVec{<:AbstractFloat}, DiffEqSolver} <: AbstractLeapfrog{T}
             ϵ::T
-            algorithm::DiffEqSolver
+            solver::DiffEqSolver
         end
 
         function step(
-            lf::DiffEqIntegrator,
+            integrator::DiffEqIntegrator,
             h::Hamiltonian,
             z::P,
             n_steps::Int=1;
@@ -26,14 +26,15 @@ function __init__()
 			f1(v, u, p, t) = -∂H∂θ(h, u).gradient
 			f2(v, u, p, t) = ∂H∂r(h, v)
 
-            ϵ = fwd ? step_size(lf) : -step_size(lf)
+            ϵ = fwd ? step_size(integrator) : -step_size(integrator)
             tspan = (0.0, sign(n_steps))
-            prob = DynamicalODEProblem(f1, f2, v0, u0, tspan)
-            integrator = init(prob, lf.alg, save_everystep=false, save_start=false, save_end=false, dt=ϵ)
+            problem = DynamicalODEProblem(f1, f2, v0, u0, tspan)
+            diffeq_integrator = init(problem, integrator.solver, save_everystep=false, save_start=false, save_end=false, dt=ϵ)
 
             for i in 1:abs(n_steps)
-                step!(integrator)
-                z = phasepoint(h, integrator.u.x[2], integrator.u.x[1])
+                step!(diffeq_integrator)
+                solution = diffeq_integrator.u.x  # (r, θ) at the proposed step
+                z = phasepoint(h, solution[2], solution[1])
                 !isfinite(z) && break
                 if res isa Vector
                     res[i] = z

--- a/src/init.jl
+++ b/src/init.jl
@@ -21,10 +21,10 @@ function __init__()
             # For DynamicalODEProblem `u` is `θ` and `v` is `r`
             # f1 is dr/dt RHS function
             # f2 is dθ/dt RHS function
-			v0, u0 = r, θ
+            v0, u0 = r, θ
 
-			f1(v, u, p, t) = -∂H∂θ(h, u).gradient
-			f2(v, u, p, t) = ∂H∂r(h, v)
+            f1(v, u, p, t) = -∂H∂θ(h, u).gradient
+            f2(v, u, p, t) = ∂H∂r(h, v)
 
             ϵ = fwd ? step_size(integrator) : -step_size(integrator)
             tspan = (0.0, sign(n_steps))
@@ -42,10 +42,10 @@ function __init__()
                     res = z
                 end
             end
-			return res
-		end
+            return res
+        end
 
-		export DiffEqIntegrator
+        export DiffEqIntegrator
 
     end
 end

--- a/src/init.jl
+++ b/src/init.jl
@@ -3,10 +3,9 @@ function __init__()
 
         using .OrdinaryDiffEq
 
-        struct DiffEqIntegrator{T<:AbstractScalarOrVec{<:AbstractFloat},A} <: AbstractLeapfrog{T}
+        struct DiffEqIntegrator{T<:AbstractScalarOrVec{<:AbstractFloat}, DiffEqSolver} <: AbstractLeapfrog{T}
             ϵ::T
-            alg::A
-            DiffEqIntegrator(ϵ::T, alg::A=VelocityVerlet()) where {T,A} = new{T,A}(ϵ, alg)
+            algorithm::DiffEqSolver
         end
 
         function step(

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,9 +1,12 @@
 function __init__()
     @require OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed" begin
+		
+		using OrdinaryDiffEq
 
-        struct DiffEqIntegrator{A}
-          alg::A
-          DiffEqIntegrator(alg::T=VelocityVerlet()) where T = new{T}(alg)
+        struct DiffEqIntegrator{T<:AbstractScalarOrVec{<:AbstractFloat},A} <: AbstractLeapfrog{T}
+            ϵ     ::    T
+            alg   ::    A
+            DiffEqIntegrator(ϵ::T, alg::A=VelocityVerlet()) where {T,A} = new{T,A}(ϵ, alg)
         end
 
         function step(
@@ -12,29 +15,27 @@ function __init__()
             z::P,
             n_steps::Int=1;
             fwd::Bool=n_steps > 0,  # simulate hamiltonian backward when n_steps < 0
-            res::Union{Vector{P}, P}=z) where P
+            res::Union{Vector{P}, P}=z) where {P<:PhasePoint}
 
             @unpack θ, r = z
-            u0 = θ
-            v0 = r
-            function f1(v,u,p,t)
-              ∂H∂r(h, θ)[2]
-            end
-            function f2(v,u,p,t)
-              ∂H∂θ(h, θ)[2]
-            end
+			v0, u0 = r, θ
+			
+			f1(v, u, p, t) = ∂H∂θ(h, v).gradient
+			f2(v, u, p, t) = ∂H∂r(h, u)
+			
             ϵ = fwd ? step_size(lf) : -step_size(lf)
-            tspan = (0.0,sign(n_steps)*1.0) # Ignored and only used for direction
-            prob = DynamicalODEProblem(f1,f2,v0,u0,tspan)
-            integrator = init(prob,lf.alg,save_everystep=false,save_start=false,
-                              save_end=false,dt=ϵ)
+            tspan = (0.0, sign(n_steps) * 1.0)  # ignored and only used for direction
+            prob = DynamicalODEProblem(f1, f2, v0, u0, tspan)
+            integrator = init(prob, lf.alg, save_everystep=false, save_start=false, save_end=false, dt=ϵ)
 
             for i in 1:abs(n_steps)
-              step!(integrator)
-            end
-
-            integrator.u.x[2]
-        end
+                step!(integrator)
+			end
+			
+			return phasepoint(h, integrator.u.x[2], integrator.u.x[1])
+		end
+		
+		export DiffEqIntegrator
 
     end
 end

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,11 +1,11 @@
 function __init__()
     @require OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed" begin
-		
-		using OrdinaryDiffEq
+
+        using OrdinaryDiffEq
 
         struct DiffEqIntegrator{T<:AbstractScalarOrVec{<:AbstractFloat},A} <: AbstractLeapfrog{T}
-            ϵ     ::    T
-            alg   ::    A
+            ϵ::T
+            alg::A
             DiffEqIntegrator(ϵ::T, alg::A=VelocityVerlet()) where {T,A} = new{T,A}(ϵ, alg)
         end
 
@@ -18,23 +18,33 @@ function __init__()
             res::Union{Vector{P}, P}=z) where {P<:PhasePoint}
 
             @unpack θ, r = z
+
+            # For DynamicalODEProblem `u` is `θ` and `v` is `r`
+            # f1 is dr/dt RHS function
+            # f2 is dθ/dt RHS function
 			v0, u0 = r, θ
-			
-			f1(v, u, p, t) = ∂H∂θ(h, v).gradient
-			f2(v, u, p, t) = ∂H∂r(h, u)
-			
+
+			f1(v, u, p, t) = -∂H∂θ(h, u).gradient
+			f2(v, u, p, t) = ∂H∂r(h, v)
+
             ϵ = fwd ? step_size(lf) : -step_size(lf)
-            tspan = (0.0, sign(n_steps) * 1.0)  # ignored and only used for direction
+            tspan = (0.0, sign(n_steps))
             prob = DynamicalODEProblem(f1, f2, v0, u0, tspan)
             integrator = init(prob, lf.alg, save_everystep=false, save_start=false, save_end=false, dt=ϵ)
 
             for i in 1:abs(n_steps)
                 step!(integrator)
-			end
-			
-			return phasepoint(h, integrator.u.x[2], integrator.u.x[1])
+                z = phasepoint(h, integrator.u.x[2], integrator.u.x[1])
+                !isfinite(z) && break
+                if res isa Vector
+                    res[i] = z
+                else
+                    res = z
+                end
+            end
+			return res
 		end
-		
+
 		export DiffEqIntegrator
 
     end

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,7 +1,7 @@
 function __init__()
     @require OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed" begin
 
-        using OrdinaryDiffEq
+        using .OrdinaryDiffEq
 
         struct DiffEqIntegrator{T<:AbstractScalarOrVec{<:AbstractFloat},A} <: AbstractLeapfrog{T}
             ϵ::T

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -48,7 +48,7 @@ function adapt!(
 )
     isadapted = false
     if i <= n_adapts
-        i == 1 && initialize!(adaptor, n_adapts)
+        i == 1 && Adaptation.initialize!(adaptor, n_adapts)
         adapt!(adaptor, θ, α)
         i == n_adapts && finalize!(adaptor)
         h, τ = update(h, τ, adaptor)

--- a/test/integrator.jl
+++ b/test/integrator.jl
@@ -79,7 +79,7 @@ using Statistics: mean
     ϵ = 0.01
     for lf in [
         Leapfrog(ϵ),
-        DiffEqIntegrator(ϵ)
+        DiffEqIntegrator(ϵ, VerletLeapfrog())
     ]
         q_init = randn(D)
         h = Hamiltonian(UnitEuclideanMetric(D), negU, ∂negU∂q)


### PR DESCRIPTION
This PR provides an interface to DifferentialEquations.jl solvers to integrate the HMC ODE system. The example from README works just by changing `int` variable.
Here is the snippet to use `CalvoSanz4` integrator:
```julia
### Define the target distribution and its gradient
using Distributions: logpdf, MvNormal
using DiffResults: GradientResult, value, gradient
using ForwardDiff: gradient!

D = 10
target = MvNormal(zeros(D), ones(D))
ℓπ(θ) = logpdf(target, θ)

function ∂ℓπ∂θ(θ)
    res = GradientResult(θ)
    gradient!(res, ℓπ, θ)
    return (value(res), gradient(res))
end

### Build up a HMC sampler to draw samples
using AdvancedHMC

# Sampling parameter settings
n_samples, n_adapts = 12_000, 2_000

# Draw a random starting points
θ_init = rand(D)

# Define metric space, Hamiltonian, sampling method and adaptor
metric = DiagEuclideanMetric(D)
h = Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
using OrdinaryDiffEq
int = DiffEqIntegrator(find_good_eps(h, θ_init), CalvoSanz4()) # (step_size, DiffEqSolver())
prop = NUTS{MultinomialTS,GeneralisedNoUTurn}(int)
adaptor = StanHMCAdaptor(
    Preconditioner(metric), 
    NesterovDualAveraging(0.8, int)
)

# Draw samples via simulating Hamiltonian dynamics
# - `samples` will store the samples
# - `stats` will store statistics for each sample
samples, stats = sample(h, prop, θ_init, n_samples, adaptor, n_adapts; progress=true)
```

Available integrators are listed [here](https://docs.juliadiffeq.org/latest/solvers/dynamical_solve/#Symplectic-Integrators-1).

Ref. #145 