### PR TITLE
Use import for OrdinaryDiffEq to prevent initialize! clash

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -1,7 +1,7 @@
 function __init__()
     @require OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed" begin
 
-        using .OrdinaryDiffEq
+        import .OrdinaryDiffEq
 
         struct DiffEqIntegrator{T<:AbstractScalarOrVec{<:AbstractFloat}, DiffEqSolver} <: AbstractLeapfrog{T}
             ϵ::T
@@ -28,11 +28,11 @@ function __init__()
 
             ϵ = fwd ? step_size(integrator) : -step_size(integrator)
             tspan = (0.0, sign(n_steps))
-            problem = DynamicalODEProblem(f1, f2, v0, u0, tspan)
-            diffeq_integrator = init(problem, integrator.solver, save_everystep=false, save_start=false, save_end=false, dt=ϵ)
+            problem = OrdinaryDiffEq.DynamicalODEProblem(f1, f2, v0, u0, tspan)
+            diffeq_integrator = OrdinaryDiffEq.init(problem, integrator.solver, save_everystep=false, save_start=false, save_end=false, dt=ϵ)
 
             for i in 1:abs(n_steps)
-                step!(diffeq_integrator)
+                OrdinaryDiffEq.step!(diffeq_integrator)
                 solution = diffeq_integrator.u.x  # (r, θ) at the proposed step
                 z = phasepoint(h, solution[2], solution[1])
                 !isfinite(z) && break


### PR DESCRIPTION
I came across 
```
ERROR: UndefVarError: initialize! not defined
Stacktrace:
 [1] #AHMCAdaptor#35(::Float64, ::typeof(Turing.Inference.AHMCAdaptor), ::Turing.Inference.NUTS{Turing.Core.ForwardDiffAD{40},(),AdvancedHMC.Adaptation.DiagEuclideanMetric}, ::AdvancedHMC.Adaptation.DiagEuclideanMetric{Float64,Array{Float64,1}}) at /Users/vaibhav/.julia/packages/Turing/a0nSz/src/inference/hmc.jl:510
 [2] #AHMCAdaptor at ./none:0 [inlined]
 [3] #HMCState#37(::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Type{Turing.Inference.HMCState}, ::DynamicPPL.Model{DiffEqBayes.var"#mf#10"{Array{InverseGamma{Float64},1},DiffEqBayes.var"#8#17",Array{Symbol,1},Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},ODEProblem{Array{Float64,1},Tuple{Float64,Float64},true,Array{Float64,1},var"##439"{var"#9#13",var"#10#14",var"#11#15",Nothing,Nothing,var"#12#16",Expr,Expr},Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},DiffEqBase.StandardODEProblem},OrdinaryDiffEq.Tsit5,Array{Float64,1},Array{Normal{Float64},1}},NamedTuple{(:x,),Tuple{Array{Float64,2}}},DynamicPPL.ModelGen{(),Nothing,Nothing},Val{()}}, ::DynamicPPL.Sampler{Turing.Inference.NUTS{Turing.Core.ForwardDiffAD{40},(),AdvancedHMC.Adaptation.DiagEuclideanMetric},Turing.Inference.SamplerState{DynamicPPL.VarInfo{NamedTuple{(:a, :σ1),Tuple{DynamicPPL.Metadata{Dict{DynamicPPL.VarName{:a},Int64},Array{Normal{Float64},1},Array{DynamicPPL.VarName{:a},1},Array{Float64,1},Array{Set{DynamicPPL.Selector},1}},DynamicPPL.Metadata{Dict{DynamicPPL.VarName{:σ1},Int64},Array{InverseGamma{Float64},1},Array{DynamicPPL.VarName{:σ1},1},Array{Float64,1},Array{Set{DynamicPPL.Selector},1}}}},Float64}}}, ::Random._GLOBAL_RNG) at /Users/vaibhav/.julia/packages/Turing/a0nSz/src/inference/hmc.jl:564
```

while updating DiffEqBayes.jl to v8 of Turing. This PR will help in avoiding that going forward.