### PR TITLE
Benchmarking utilites, models and scripts

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,6 +36,7 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 Bijectors = "76274a88-744f-5084-9051-94815aaf08c4"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 
 [targets]
-test = ["Distributed", "Distributions", "ForwardDiff", "Test", "Turing", "UnicodePlots", "Bijectors", "OrdinaryDiffEq", "Zygote"]
+test = ["Distributed", "Distributions", "ForwardDiff", "Test", "Turing", "UnicodePlots", "Bijectors", "OrdinaryDiffEq", "Zygote", "ReverseDiff"]

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ If you are interested in using `AdvancedHMC.jl` through a probabilistic programm
 ## A minimal example - sampling from a multivariate Gaussian using NUTS
 
 ```julia
-
-using AdvancedHMC, Distributions, ForwardDiff
+using AdvancedHMC, Distributions, ReverseDiff
 
 # Choose parameter dimentionality and initial parameter value
 D = 10; initial_θ = rand(D)   
@@ -36,7 +35,7 @@ n_samples, n_adapts = 2_000, 1_000
 
 # Define a Hamiltonian system
 metric = DiagEuclideanMetric(D)
-hamiltonian = Hamiltonian(metric, ℓπ, ForwardDiff)  
+hamiltonian = Hamiltonian(metric, ℓπ, ReverseDiff)  
 
 # Define a leapfrog solver, with initial step size chosen heuristically
 initial_ϵ = find_good_eps(hamiltonian, initial_θ) 
@@ -96,7 +95,8 @@ where `int` is the integrator used.
 - Combine the first two using Stan's windowed adaptation: `StanHMCAdaptor(pc, da)`
 
 ### Gradients 
-`AdvancedHMC` supports both AD-based (`Zygote`, `Tracker` and `ForwardDiff`) and user-specified gradients. For the latter, simply replace `ForwardDiff` with `ℓπ_grad` in the ` Hamiltonian`  constructor. 
+`AdvancedHMC` supports both AD-based (`Zygote`, `ReverseDiff` and `ForwardDiff`) and user-specified gradients. 
+For the latter, simply replace `ForwardDiff` with `ℓπ_grad` in the ` Hamiltonian`  constructor. 
 
 All the combinations are tested in [this file](https://github.com/TuringLang/AdvancedHMC.jl/blob/master/test/hmc.jl) except from using tempered leapfrog integrator together with adaptation, which we found unstable empirically.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you are interested in using `AdvancedHMC.jl` through a probabilistic programm
 ## A minimal example - sampling from a multivariate Gaussian using NUTS
 
 ```julia
-using AdvancedHMC, Distributions, ReverseDiff
+using AdvancedHMC, Distributions, Zygote
 
 # Choose parameter dimentionality and initial parameter value
 D = 10; initial_θ = rand(D)   
@@ -35,7 +35,7 @@ n_samples, n_adapts = 2_000, 1_000
 
 # Define a Hamiltonian system
 metric = DiagEuclideanMetric(D)
-hamiltonian = Hamiltonian(metric, ℓπ, ReverseDiff)  
+hamiltonian = Hamiltonian(metric, ℓπ, Zygote)  
 
 # Define a leapfrog solver, with initial step size chosen heuristically
 initial_ϵ = find_good_eps(hamiltonian, initial_θ) 

--- a/benchmarks/ahmc.jl
+++ b/benchmarks/ahmc.jl
@@ -56,11 +56,9 @@ function main()
         return run_hmc(ns, nc, n_dims, ℓπ, ∂ℓπ∂θ)
     end
 
-    # To get rid of compilation time
-    run_hmc_on_target(1, n_chains)
-
     for i_run in 1:n_runs
         print("Running $i_run ...")
+        run_hmc_on_target(1, n_chains)  # to get rid of compilation time
         val, t, bytes, gctime, memallocs = @timed run_hmc_on_target(n_samples, n_chains)
         println(" Done! $(lpad(round(t; digits=3), 7)) seconds used")
     end

--- a/benchmarks/ahmc.jl
+++ b/benchmarks/ahmc.jl
@@ -1,0 +1,69 @@
+include(joinpath(@__DIR__, "argparse.jl"))
+
+using AdvancedHMC, ForwardDiff, Zygote, ReverseDiff
+
+const ADDICT = Dict(
+    "forwarddiff" => ForwardDiff,
+    "zygote"      => Zygote,
+    "reversediff" => ReverseDiff,
+)
+
+const T = Float32
+
+target_dir = joinpath(@__DIR__, "targets")
+for fname in readdir(target_dir)
+    include(joinpath(target_dir, fname))
+end
+
+const TARGETDICT = Dict(
+    "gaussian" => ℓπ_gaussian,
+    "mog"      => ℓπ_mog,
+    "gdemo"    => ℓπ_gdemo,
+)
+
+function run_hmc(n_samples::Int, n_chains::Int, n_dims::Int, ℓπ, ∂ℓπ∂θ; ϵ=0.01, n_steps=4)
+    initial_θ = n_chains == 1 ? zeros(T, n_dims) : zeros(T, n_dims, n_chains)
+    metric = UnitEuclideanMetric(T, size(initial_θ))
+    hamiltonian = Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
+    integrator = Leapfrog(T(ϵ))
+    proposal = StaticTrajectory(integrator, n_steps)
+    samples, stats = sample(hamiltonian, proposal, initial_θ, n_samples; progress=false, verbose=false)
+end
+
+function main()
+    parsed_args = parse_commandline()
+    @info "Args" parsed_args...
+    n_dims    = parsed_args[:n_dims]
+    n_samples = parsed_args[:n_samples]
+    n_chains  = parsed_args[:n_chains]
+    n_runs    = parsed_args[:n_runs]
+    target    = parsed_args[:target]
+    ad        = parsed_args[:ad]
+
+    if target == "gdemo"
+        @assert n_dims == 2 "gdemo only supports n_dims=2."
+    end
+    ℓπ = TARGETDICT[target]
+
+    if ad == "hand"
+        @assert target == "gaussian" "Only gaussian supports hand coded gradient"
+        ∂ℓπ∂θ = ∂ℓπ∂θ_gaussian
+    else
+        ∂ℓπ∂θ = ADDICT[ad]
+    end
+
+    function run_hmc_on_target(ns, nc)
+        return run_hmc(ns, nc, n_dims, ℓπ, ∂ℓπ∂θ)
+    end
+
+    # To get rid of compilation time
+    run_hmc_on_target(1, n_chains)
+
+    for i_run in 1:n_runs
+        print("Running $i_run ...")
+        val, t, bytes, gctime, memallocs = @timed run_hmc_on_target(n_samples, n_chains)
+        println(" Done! $(lpad(round(t; digits=3), 7)) seconds used")
+    end
+end
+
+main()

--- a/benchmarks/ahmc.jl
+++ b/benchmarks/ahmc.jl
@@ -21,13 +21,17 @@ const TARGETDICT = Dict(
     "gdemo"    => ℓπ_gdemo,
 )
 
-function run_hmc(n_samples::Int, n_chains::Int, n_dims::Int, ℓπ, ∂ℓπ∂θ; ϵ=0.01, n_steps=4)
+function run_hmc(n_samples::Int, n_chains::Int, n_dims::Int, ℓπ, ∂ℓπ∂θ; ϵ=T(0.01), n_steps=4, grad_only=false)
     initial_θ = n_chains == 1 ? zeros(T, n_dims) : zeros(T, n_dims, n_chains)
     metric = UnitEuclideanMetric(T, size(initial_θ))
     hamiltonian = Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
-    integrator = Leapfrog(T(ϵ))
-    proposal = StaticTrajectory(integrator, n_steps)
-    samples, stats = sample(hamiltonian, proposal, initial_θ, n_samples; progress=false, verbose=false)
+    if grad_only
+        [hamiltonian.∂ℓπ∂θ(initial_θ) for i in 1:n_steps*n_samples]
+    else
+        integrator = Leapfrog(T(ϵ))
+        proposal = StaticTrajectory(integrator, n_steps)
+        samples, stats = sample(hamiltonian, proposal, initial_θ, n_samples; progress=false, verbose=false)
+    end
 end
 
 function main()

--- a/benchmarks/argparse.jl
+++ b/benchmarks/argparse.jl
@@ -7,6 +7,7 @@ function parse_commandline()
         "--n_dims"
             help = "Dimensionality of target space"
             arg_type = Int
+            nargs = '*'
             required = true
         "--n_samples"
             help = "Number of samples to draw"
@@ -15,6 +16,7 @@ function parse_commandline()
         "--n_chains"
             help = "Number of chains to run"
             arg_type = Int
+            nargs = '*'
             required = true
         "--target"
             help = "Target distribution"

--- a/benchmarks/argparse.jl
+++ b/benchmarks/argparse.jl
@@ -16,10 +16,12 @@ function parse_commandline()
         "--target"
             arg_type = String
             required = true
-            range_tester = (x -> x in ("mog", "gauss"))
+            range_tester = (x -> x in ("mog", "gaussian"))
         "--use_xla"
             arg_type = Bool
             default = true
+        "--check_typed"
+            action = :store_true
     end
 
     parsed_args = parse_args(s; as_symbols=true)

--- a/benchmarks/argparse.jl
+++ b/benchmarks/argparse.jl
@@ -1,0 +1,27 @@
+using ArgParse
+
+function parse_commandline()
+    s = ArgParseSettings()
+
+    @add_arg_table s begin
+        "--n_dims"
+            arg_type = Int
+            required = true
+        "--n_samples"
+            arg_type = Int
+            required = true
+        "--n_chains"
+            arg_type = Int
+            required = true
+        "--target"
+            arg_type = String
+            required = true
+            range_tester = (x -> x in ("mog", "gauss"))
+        "--use_xla"
+            arg_type = Bool
+            default = true
+    end
+
+    parsed_args = parse_args(s; as_symbols=true)
+
+end

--- a/benchmarks/argparse.jl
+++ b/benchmarks/argparse.jl
@@ -5,22 +5,36 @@ function parse_commandline()
 
     @add_arg_table s begin
         "--n_dims"
+            help = "Dimensionality of target space"
             arg_type = Int
             required = true
         "--n_samples"
+            help = "Number of samples to draw"
             arg_type = Int
             required = true
         "--n_chains"
+            help = "Number of chains to run"
             arg_type = Int
             required = true
         "--target"
+            help = "Target distribution"
             arg_type = String
             required = true
             range_tester = (x -> x in ("mog", "gaussian"))
-        "--use_xla"
-            arg_type = Bool
-            default = true
+        "--ad"
+            help = "AD backend to use (AdvancedHMC only)"
+            arg_type = String
+            default  = "zygote"
+            range_tester = (x -> x in ("zygote", "forwarddiff", "reversediff", "hand"))
+        "--n_runs"
+            help = "Number of runs to perform"
+            arg_type = Int
+            default  = 3
+        "--no_xla"
+            help ="Disable XLA compilation for TensorFLow Probability"
+            action = :store_false
         "--check_typed"
+            help ="Whether or not to check type stability for Julia models"
             action = :store_true
     end
 

--- a/benchmarks/argparse.jl
+++ b/benchmarks/argparse.jl
@@ -38,6 +38,9 @@ function parse_commandline()
         "--check_typed"
             help ="Whether or not to check type stability for Julia models"
             action = :store_true
+        "--grad_only"
+            help ="Only check the gradient time"
+            action = :store_true
     end
 
     parsed_args = parse_args(s; as_symbols=true)

--- a/benchmarks/makeplots.jl
+++ b/benchmarks/makeplots.jl
@@ -1,0 +1,44 @@
+run_time_list_tfp_xla = [
+    [3.090347766876220, 2.828183174133301, 3.014273643493652, 4.196374416351318, 10.497739553451538],
+    [3.114380121231079, 2.841257333755493, 3.200836181640625, 4.058141469955444, 10.449615716934204],
+    [2.979512691497802, 2.800515413284301, 3.025217056274414, 4.022154331207275,  9.217156887054443],
+]
+run_time_list_ahmc = [
+    [2.474283462, 2.775114306, 4.474204685, 17.148073437, 142.031350136],
+    [1.968109331, 2.581849350, 4.587503092, 18.799088301, 154.755842153],
+    [2.350790260, 2.842742620, 4.750033486, 18.714588798, 142.333408883],
+]
+
+using MLToolkit.Plots
+
+fig, ax = plt.subplots()
+
+plot!(ax, LinesWithErrorBar(n_chains_list, run_time_list_tfp_xla); label="TFP (XLA)")
+plot!(ax, LinesWithErrorBar(n_chains_list, run_time_list_ahmc); label="AdvancedHMC")
+
+ax.set_xlabel("Number of chains")
+ax.set_ylabel("Sampling time (s)")
+ax.set_xscale("log")
+ax.set_yscale("log")
+ax.set_title("Vectorized mode on CPU")
+plt.legend()
+savefig(fig, "")
+
+run_time_list_forwarddiff_dist  = [0.109947149, 0.103731421, 0.131234604, 0.190311801, 0.446025397, 1.056527587, 3.213806697, 11.083078182, 38.082333896]
+run_time_list_forwarddiff_distX = [0.090850415, 0.764131722, 0.812617863, 1.014190059, 0.648893597, 2.299574609, 5.418227988, 10.502449656, 33.848247298]
+run_time_list_zygote_dist       = [4.423139535, 4.847198919, 6.281013862, 9.219753507, 14.85712963, 27.256743158, 50.974715499, 97.031564813, 179.80131999]
+run_time_list_zygote_distX      = [1.82309049, 1.793467318, 1.837250077, 1.941552501, 2.091833956, 2.387725306, 2.959626034, 3.983277249, 5.701385978]
+
+using MLToolkit.Plots
+
+fig, ax = plt.subplots()
+ax.plot(n_chains_list, run_time_list_forwarddiff,       "-x", label="ForwardDiff")
+ax.plot(n_chains_list, run_time_list_forwarddiff_distX, "-x", label="ForwardDiff (DistX)")
+ax.plot(n_chains_list, run_time_list_zygote,            "-x", label="Zygote")
+ax.plot(n_chains_list, run_time_list_zygote_distX,      "-x", label="Zygote (DistX)")
+ax.set_xlabel("Number of chains")
+ax.set_ylabel("Sampling time (s)")
+ax.set_xscale("log")
+ax.set_yscale("log")
+plt.legend()
+fig

--- a/benchmarks/targets/gaussian.jl
+++ b/benchmarks/targets/gaussian.jl
@@ -1,20 +1,20 @@
 using InteractiveUtils: @code_warntype
 
-function ℓπ_gaussian(m, s, x::AbstractVecOrMat{T}) where {T}
+function ℓπ_gaussian_impl(m, s, x::AbstractVecOrMat{T}) where {T}
     diff = x .- m
     v = s.^2
     return -(log(2 * T(pi)) .+ log.(v) .+ diff .* diff ./ v) / 2
 end
 
 function ℓπ_gaussian(m, s, x::AbstractVector)
-    return sum(ℓπ_gaussian(m, s, x))
+    return sum(ℓπ_gaussian_impl(m, s, x))
 end
 
 function ℓπ_gaussian(m, s, x::AbstractMatrix)
-    return dropdims(sum(ℓπ_gaussian(m, s, x); dims=1); dims=1)
+    return dropdims(sum(ℓπ_gaussian_impl(m, s, x); dims=1); dims=1)
 end
 
-function ∂ℓπ∂θ_gaussian(m, s, x::AbstractVecOrMat{T}) where {T}
+function ∂ℓπ∂θ_gaussian_impl(m, s, x::AbstractVecOrMat{T}) where {T}
     diff = x .- m
     v = s.^2
     v = -(log(2 * T(pi)) .+ log.(v) .+ diff .* diff ./ v) / 2
@@ -23,12 +23,12 @@ function ∂ℓπ∂θ_gaussian(m, s, x::AbstractVecOrMat{T}) where {T}
 end
 
 function ∂ℓπ∂θ_gaussian(m, s, x::AbstractVector)
-    v, g = ∂ℓπ∂θ_gaussian(m, s, x)
+    v, g = ∂ℓπ∂θ_gaussian_impl(m, s, x)
     return sum(v), g
 end
 
 function ∂ℓπ∂θ_gaussian(m, s, x::AbstractMatrix)
-    v, g = ∂ℓπ∂θ_gaussian(m, s, x)
+    v, g = ∂ℓπ∂θ_gaussian_impl(m, s, x)
     return dropdims(sum(v; dims=1); dims=1), g
 end
 

--- a/benchmarks/targets/gaussian.jl
+++ b/benchmarks/targets/gaussian.jl
@@ -1,0 +1,54 @@
+using InteractiveUtils: @code_warntype
+
+function ℓπ_gaussian(m, s, x::AbstractVecOrMat{T}) where {T}
+    diff = x .- m
+    v = s.^2
+    return -(log(2 * T(pi)) .+ log.(v) .+ diff .* diff ./ v) / 2
+end
+
+function ℓπ_gaussian(m, s, x::AbstractVector)
+    return sum(ℓπ_gaussian(m, s, x))
+end
+
+function ℓπ_gaussian(m, s, x::AbstractMatrix)
+    return dropdims(sum(ℓπ_gaussian(m, s, x); dims=1); dims=1)
+end
+
+function ∂ℓπ∂θ_gaussian(m, s, x::AbstractVecOrMat{T}) where {T}
+    diff = x .- m
+    v = s.^2
+    v = -(log(2 * T(pi)) .+ log.(v) .+ diff .* diff ./ v) / 2
+    g = -diff
+    return v, g
+end
+
+function ∂ℓπ∂θ_gaussian(m, s, x::AbstractVector)
+    v, g = ∂ℓπ∂θ_gaussian(m, s, x)
+    return sum(v), g
+end
+
+function ∂ℓπ∂θ_gaussian(m, s, x::AbstractMatrix)
+    v, g = ∂ℓπ∂θ_gaussian(m, s, x)
+    return dropdims(sum(v; dims=1); dims=1), g
+end
+
+const T = Float32
+const gaussian_m = zero(T)
+const gaussian_s = one(T)
+
+ℓπ_gaussian(x) = ℓπ_gaussian(gaussian_m, gaussian_s, x)
+∂ℓπ∂θ_gaussian(x) = ∂ℓπ∂θ_gaussian(gaussian_m, gaussian_s, x)
+
+function check_typed_gaussian()
+    x = zeros(T, 2)
+    @code_warntype ℓπ_gaussian(gaussian_m, gaussian_s, x)
+    @code_warntype ∂ℓπ∂θ_gaussian(gaussian_m, gaussian_s,x)
+    
+    x = zeros(T, 2, 2)
+    @code_warntype ℓπ_gaussian(gaussian_m, gaussian_s,x)
+    @code_warntype ∂ℓπ∂θ_gaussian(gaussian_m, gaussian_s,x)
+end
+
+if "--check_typed" in ARGS
+    check_typed_gaussian()
+end

--- a/benchmarks/targets/gdemo.jl
+++ b/benchmarks/targets/gdemo.jl
@@ -1,0 +1,24 @@
+# For the Turing model
+# @model gdemo() = begin
+#     s ~ InverseGamma(2, 3)
+#     m ~ Normal(0, sqrt(s))
+#     1.5 ~ Normal(m, sqrt(s))
+#     2.0 ~ Normal(m, sqrt(s))
+#     return s, m
+# end
+
+using Distributions: logpdf, InverseGamma, Normal
+using Bijectors: invlink, logpdf_with_trans
+
+function invlink_gdemo(θ)
+    s = invlink(InverseGamma(2, 3), θ[1])
+    m = θ[2]
+    return [s, m]
+end
+
+function ℓπ_gdemo(θ)
+    s, m = invlink_gdemo(θ)
+    logprior = logpdf_with_trans(InverseGamma(2, 3), s, true) + logpdf(Normal(0, sqrt(s)), m)
+    loglikelihood = logpdf(Normal(m, sqrt(s)), 1.5) + logpdf(Normal(m, sqrt(s)), 2.0)
+    return logprior + loglikelihood
+end

--- a/benchmarks/targets/gdemo.jl
+++ b/benchmarks/targets/gdemo.jl
@@ -28,7 +28,7 @@ function get_gdemo()
     return (ℓπ=ℓπ_gdemo, invlink=invlink_gdemo, θ̄=[49 / 24, 7 / 6])
 end
 
-function check_typed()
+function check_typed_gdemo()
     ℓπ_gdemo, invlink_gdemo = get_gdemo()
 
     x = zeros(2)
@@ -37,5 +37,5 @@ function check_typed()
 end
 
 if "--check_typed" in ARGS
-    check_typed()
+    check_typed_gdemo()
 end

--- a/benchmarks/targets/gdemo.jl
+++ b/benchmarks/targets/gdemo.jl
@@ -11,26 +11,22 @@ using Distributions: logpdf, InverseGamma, Normal
 using Bijectors: invlink, logpdf_with_trans
 using InteractiveUtils: @code_warntype
 
-function get_gdemo()
-    function invlink_gdemo(θ)
-        s = invlink(InverseGamma(2, 3), θ[1])
-        m = θ[2]
-        return [s, m]
-    end
-
-    function ℓπ_gdemo(θ)
-        s, m = invlink_gdemo(θ)
-        logprior = logpdf_with_trans(InverseGamma(2, 3), s, true) + logpdf(Normal(0, sqrt(s)), m)
-        loglikelihood = logpdf(Normal(m, sqrt(s)), 1.5) + logpdf(Normal(m, sqrt(s)), 2.0)
-        return logprior + loglikelihood
-    end
-
-    return (ℓπ=ℓπ_gdemo, invlink=invlink_gdemo, θ̄=[49 / 24, 7 / 6])
+function invlink_gdemo(θ)
+    s = invlink(InverseGamma(2, 3), θ[1])
+    m = θ[2]
+    return [s, m]
 end
 
-function check_typed_gdemo()
-    ℓπ_gdemo, invlink_gdemo = get_gdemo()
+function ℓπ_gdemo(θ)
+    s, m = invlink_gdemo(θ)
+    logprior = logpdf_with_trans(InverseGamma(2, 3), s, true) + logpdf(Normal(0, sqrt(s)), m)
+    loglikelihood = logpdf(Normal(m, sqrt(s)), 1.5) + logpdf(Normal(m, sqrt(s)), 2.0)
+    return logprior + loglikelihood
+end
 
+const θ̄_gdemo = [49 / 24, 7 / 6]
+
+function check_typed_gdemo()
     x = zeros(2)
     @code_warntype ℓπ_gdemo(x)
     @code_warntype invlink_gdemo(x)

--- a/benchmarks/targets/gdemo.jl
+++ b/benchmarks/targets/gdemo.jl
@@ -1,4 +1,4 @@
-# For the Turing model
+# The most famous Turing model
 # @model gdemo() = begin
 #     s ~ InverseGamma(2, 3)
 #     m ~ Normal(0, sqrt(s))
@@ -9,16 +9,33 @@
 
 using Distributions: logpdf, InverseGamma, Normal
 using Bijectors: invlink, logpdf_with_trans
+using InteractiveUtils: @code_warntype
 
-function invlink_gdemo(θ)
-    s = invlink(InverseGamma(2, 3), θ[1])
-    m = θ[2]
-    return [s, m]
+function get_gdemo()
+    function invlink_gdemo(θ)
+        s = invlink(InverseGamma(2, 3), θ[1])
+        m = θ[2]
+        return [s, m]
+    end
+
+    function ℓπ_gdemo(θ)
+        s, m = invlink_gdemo(θ)
+        logprior = logpdf_with_trans(InverseGamma(2, 3), s, true) + logpdf(Normal(0, sqrt(s)), m)
+        loglikelihood = logpdf(Normal(m, sqrt(s)), 1.5) + logpdf(Normal(m, sqrt(s)), 2.0)
+        return logprior + loglikelihood
+    end
+
+    return (ℓπ=ℓπ_gdemo, invlink=invlink_gdemo, θ̄=[49 / 24, 7 / 6])
 end
 
-function ℓπ_gdemo(θ)
-    s, m = invlink_gdemo(θ)
-    logprior = logpdf_with_trans(InverseGamma(2, 3), s, true) + logpdf(Normal(0, sqrt(s)), m)
-    loglikelihood = logpdf(Normal(m, sqrt(s)), 1.5) + logpdf(Normal(m, sqrt(s)), 2.0)
-    return logprior + loglikelihood
+function check_typed()
+    ℓπ_gdemo, invlink_gdemo = get_gdemo()
+
+    x = zeros(2)
+    @code_warntype ℓπ_gdemo(x)
+    @code_warntype invlink_gdemo(x)
+end
+
+if "--check_typed" in ARGS
+    check_typed()
 end

--- a/benchmarks/targets/mog.jl
+++ b/benchmarks/targets/mog.jl
@@ -1,0 +1,36 @@
+using InteractiveUtils: @code_warntype
+
+include("gaussian.jl")
+
+function density_mog_impl(m, s, mixing, x::AbstractArray)
+    return dropdims(sum(exp.(ℓπ_gaussian(mog_m, mog_s, x)) .* mixing; dims=1); dims=1)
+end
+
+density_mog(m, s, mixing, x::AbstractVector) = density_mog_impl(m, s, mixing, x)
+
+function density_mog(m, s, mixing, x::AbstractMatrix)
+    dim, n = size(x)
+    x = reshape(x, dim, 1, n)
+    return density_mog_impl(m, s, ximing, x)
+end
+
+ℓπ_mog(m, s, mixing, x) = log.(density_mog(m, s, mixing, x))
+
+const T = Float32
+const mog_m  = T[-2.0, 0.0, 3.2, 2.5]
+const mog_s  = T[ 1.2, 1.0, 5.0, 2.8]
+const mixing = T[ 0.2, 0.3, 0.1, 0.4]
+
+ℓπ_mog(x) = ℓπ_mog(mog_m, mog_s, mixing, x)
+
+function check_typed_mog()
+    x = zeros(T, 2)
+    @code_warntype ℓπ_mog(x)
+    
+    x = zeros(T, 2, 2)
+    @code_warntype ℓπ_mog(x)
+end
+
+if "--check_typed" in ARGS
+    check_typed_mog()
+end

--- a/benchmarks/tfp.jl
+++ b/benchmarks/tfp.jl
@@ -1,0 +1,107 @@
+# Based on https://rlouf.github.io/post/jax-random-walk-metropolis/
+
+using ArgParse, PyCall
+
+function parse_commandline()
+    s = ArgParseSettings()
+
+    @add_arg_table s begin
+        "--n_dims"
+            arg_type = Int
+            required = true
+        "--n_samples"
+            arg_type = Int
+            required = true
+        "--n_chains"
+            arg_type = Int
+            required = true
+        "--use_xla"
+            arg_type = Bool
+            required = true
+        "--target"
+            arg_type = String
+            required = true
+            range_tester = (x -> x in ("mog", "gauss"))
+    end
+
+    return parse_args(s)
+end
+
+function main()
+    parsed_args = parse_commandline()
+    n_dims = parsed_args["n_dims"]
+    n_samples = parsed_args["n_samples"]
+    n_chains = parsed_args["n_chains"]
+    use_xla = parsed_args["use_xla"]
+    target = parsed_args["target"]
+    
+    py"""
+    import os
+    os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
+
+    from functools import partial
+
+    import numpy as np
+    import tensorflow as tf
+    import tensorflow_probability as tfp
+    tfd = tfp.distributions
+
+    dtype = np.float32
+
+    def trace_everything(states, previous_kernel_results):
+        return previous_kernel_results
+
+    def hmc_sampler(n_dims, n_samples, n_chains, target):
+        samples, _ = tfp.mcmc.sample_chain(
+            num_results=n_samples,
+            current_state=np.zeros((n_dims, n_chains), dtype=dtype),
+            kernel=tfp.mcmc.HamiltonianMonteCarlo(
+                target_log_prob_fn=target.log_prob,
+                num_leapfrog_steps=4,
+                step_size=0.01
+            ),
+            trace_fn=trace_everything
+        )
+        return samples
+
+    # Define Gaussian mixtures
+    target_dict = {}
+    target_mog = tfd.Mixture(
+        cat=tfd.Categorical(probs=[0.2, 0.3, 0.1, 0.4]),
+        components=[
+            tfd.Normal(loc=dtype(-2.0), scale=dtype(1.2)),
+            tfd.Normal(loc=dtype(+0.0), scale=dtype(1.0)),
+            tfd.Normal(loc=dtype(+3.2), scale=dtype(5.0)),
+            tfd.Normal(loc=dtype(+2.5), scale=dtype(2.8)),
+        ],
+    )
+    target_dict["mog"] = target_mog
+
+    # Define Gaussian
+    target_gauss = tfd.Normal(loc=dtype(-0.0), scale=dtype(1.0))
+    target_dict["gauss"] = target_gauss
+
+    target = target_dict[$target]
+
+    import time
+
+    n_dims = $n_dims
+    n_samples = $n_samples
+    n_chains = $n_chains
+
+    ts = []
+
+    for c in [1, 10, 100, 1000, 10000]:
+        print(f"Running {c} chains")
+        run_mcm = partial(hmc_sampler, n_dims, n_samples, c, target)
+        start = time.time()
+        tf.xla.experimental.compile(run_mcm) if $use_xla else run_mcm()
+        t = time.time() - start
+        print(f"...Done with {t} seconds")
+        ts.append(t)
+
+    print(ts)
+    """
+end
+
+main()

--- a/benchmarks/tfp.jl
+++ b/benchmarks/tfp.jl
@@ -6,7 +6,7 @@ using PyCall
 
 function main()
     parsed_args = parse_commandline()
-    @assert parsed_args[:target] in ("mog", "gauss") "Only mixture of Gaussians and Gaussian targets are implemented in TFP."
+    @assert parsed_args[:target] in ("mog", "gaussian") "Only mixture of Gaussians and Gaussian targets are implemented in TFP."
     
     py"""
     import os, time
@@ -51,7 +51,7 @@ function main()
 
     # Define Gaussian
     target_gauss = tfd.Normal(loc=dtype(-0.0), scale=dtype(1.0))
-    target_dict["gauss"] = target_gauss
+    target_dict["gaussian"] = target_gauss
 
     # Choose target
     target_name = $(parsed_args[:target])

--- a/benchmarks/tfp.jl
+++ b/benchmarks/tfp.jl
@@ -51,7 +51,7 @@ function main()
     target_dict["mog"] = target_mog
 
     # Define Gaussian
-    target_gauss = tfd.Normal(loc=dtype(-0.0), scale=dtype(1.0))
+    target_gauss = tfd.Normal(loc=dtype(0.0), scale=dtype(1.0))
     target_dict["gaussian"] = target_gauss
 
     # Choose target

--- a/src/contrib/ad.jl
+++ b/src/contrib/ad.jl
@@ -80,7 +80,7 @@ end # @require
 
 import .Zygote
 
-function ∂ℓπ∂θ_reversediff(ℓπ, θ::AbstractVector)
+function ∂ℓπ∂θ_zygote(ℓπ, θ::AbstractVector)
     res, back = Zygote.pullback(ℓπ, θ)
     return res, first(back(Zygote.sensitivity(res)))
 end
@@ -111,10 +111,14 @@ function ReverseDiffADHamiltonian(metric::AbstractMetric, ℓπ)
     compiled_f_tape = ReverseDiff.compile(f_tape)
     results = similar.(inputs)
     all_results = map(DiffResults.GradientResult, results)
-    cfg = ReverseDiff.GradientConfig(inputs)
+    # cfg = ReverseDiff.GradientConfig(inputs)    # we may use this in the future; see https://github.com/JuliaDiff/ReverseDiff.jl/blob/master/examples/gradient.jl#L43
     function ∂ℓπ∂θ(θ::AbstractVector)
         ReverseDiff.gradient!(all_results, compiled_f_tape, (θ,))
         return DiffResults.value(first(all_results)), DiffResults.gradient(first(all_results))
+    end
+    # TODO: implement this
+    function ∂ℓπ∂θ(θ::AbstractMatrix)
+        error("MethodError: utility of gradient via ReverseDiff for vectorized mode is not implementation; please construct it explictly")
     end
     return Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
 end

--- a/src/contrib/ad.jl
+++ b/src/contrib/ad.jl
@@ -17,6 +17,7 @@ function Hamiltonian(metric::AbstractMetric, ℓπ)
     end
 end
 
+# FIXME: pre-allocate results for ForwardDiff as well
 ### ForwardDiff
 
 @require ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210" begin

--- a/test/demo.jl
+++ b/test/demo.jl
@@ -1,4 +1,4 @@
-using AdvancedHMC, Distributions, ReverseDiff
+using AdvancedHMC, Distributions, Zygote
 
 # Choose parameter dimentionality and initial parameter value
 D = 10; initial_θ = rand(D)   
@@ -11,7 +11,7 @@ n_samples, n_adapts = 2_000, 1_000
 
 # Define a Hamiltonian system
 metric = DiagEuclideanMetric(D)
-hamiltonian = Hamiltonian(metric, ℓπ, ReverseDiff)  
+hamiltonian = Hamiltonian(metric, ℓπ, Zygote)  
 
 # Define a leapfrog solver, with initial step size chosen heuristically
 initial_ϵ = find_good_eps(hamiltonian, initial_θ) 

--- a/test/demo.jl
+++ b/test/demo.jl
@@ -1,24 +1,30 @@
-### Define the target distribution
-using Distributions: logpdf, MvNormal
+using AdvancedHMC, Distributions, ReverseDiff
 
-D = 10
+# Choose parameter dimentionality and initial parameter value
+D = 10; initial_θ = rand(D)   
+
+# Define the target distribution
 ℓπ(θ) = logpdf(MvNormal(zeros(D), ones(D)), θ)
 
-### Build up a HMC sampler to draw samples
-using AdvancedHMC, ForwardDiff
+# Set the number of samples to draw and warmup iterations
+n_samples, n_adapts = 2_000, 1_000 
 
-# Parameter settings
-n_samples, n_adapts = 12_000, 2_000
-θ₀ = rand(D)    # draw a random starting points
-
-# Define metric space, Hamiltonian, sampling method and adaptor
+# Define a Hamiltonian system
 metric = DiagEuclideanMetric(D)
-hamiltonian = Hamiltonian(metric, ℓπ, ForwardDiff)  # or, Hamiltonian(metric, ℓπ, ∂ℓπ∂θ) for hand-coded gradient ∂ℓπ∂θ
-integrator = Leapfrog(find_good_eps(hamiltonian, θ₀))
+hamiltonian = Hamiltonian(metric, ℓπ, ReverseDiff)  
+
+# Define a leapfrog solver, with initial step size chosen heuristically
+initial_ϵ = find_good_eps(hamiltonian, initial_θ) 
+integrator = Leapfrog(initial_ϵ)
+
+# Define an HMC sampler, with the following components
+#   - multinomial sampling scheme,
+#   - generalised No-U-Turn criteria, and
+#   - windowed adaption for step-size and diagonal mass matrix
 proposal = NUTS{MultinomialTS, GeneralisedNoUTurn}(integrator)
 adaptor = StanHMCAdaptor(Preconditioner(metric), NesterovDualAveraging(0.8, integrator))
 
-# Draw samples via simulating Hamiltonian dynamics
-# - `samples` will store the samples
-# - `stats` will store statistics for each sample
-samples, stats = sample(hamiltonian, proposal, θ₀, n_samples, adaptor, n_adapts; progress=true)
+# Run the sampler to draw samples from the specified Gaussian, where
+#   - `samples` will store the samples
+#   - `stats` will store diagnostic statistics for each sample
+samples, stats = sample(hamiltonian, proposal, initial_θ, n_samples, adaptor, n_adapts; progress=true)

--- a/test/models.jl
+++ b/test/models.jl
@@ -6,13 +6,11 @@ include(joinpath(splitpath(@__DIR__)[1:end-1]..., "benchmarks", "targets", "gdem
 @testset "models" begin
 
     @testset "gdemo" begin
-        ℓπ_gdemo, invlink_gdemo, θ̄ = get_gdemo()
-
         res = run_nuts(2, ℓπ_gdemo; rng=MersenneTwister(1), verbose=true, drop_warmup=true)
 
         θ̂ = mean(map(invlink_gdemo, res.samples))
 
-        @test θ̂ ≈ θ̄ atol=RNDATOL
+        @test θ̂ ≈ θ̄_gdemo atol=RNDATOL
     end
 
 end # @testset

--- a/test/models.jl
+++ b/test/models.jl
@@ -6,11 +6,13 @@ include(joinpath(splitpath(@__DIR__)[1:end-1]..., "benchmarks", "targets", "gdem
 @testset "models" begin
 
     @testset "gdemo" begin
+        ℓπ_gdemo, invlink_gdemo, θ̄ = get_gdemo()
+
         res = run_nuts(2, ℓπ_gdemo; rng=MersenneTwister(1), verbose=true, drop_warmup=true)
 
         θ̂ = mean(map(invlink_gdemo, res.samples))
 
-        @test θ̂ ≈ [49 / 24, 7 / 6] atol=RNDATOL
+        @test θ̂ ≈ θ̄ atol=RNDATOL
     end
 
 end # @testset


### PR DESCRIPTION
Some notes:
- Main entries are `benchmarks/ahmc.jl` and `benchmarks/tfp.jl`
- Args are defined in `benchmarks/argparse.jl` - should be quite self-explained
- Targets are defined in `benchmarks/targets`
- AD utilties are in `src/contrib/ad.jl`

TODOs:
- [ ] Implement utilities for vectorized mode using ReverseDiff.jl
- [x] @willtebbutt suggested to benchmark the gradient function for different AD backends isolated as well
- [ ] Check the type stability of AD backends
