### PR TITLE
bump compat entry for ArgCheck

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedHMC"
 uuid = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
-version = "0.2.20"
+version = "0.2.21"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
@@ -16,7 +16,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 
 [compat]
-ArgCheck = "1"
+ArgCheck = "1, 2"
 InplaceOps = "0.3"
 LazyArrays = "0.9, 0.10, 0.11, 0.12, 0.13, 0.14"
 Parameters = "0.10, 0.11, 0.12"


### PR DESCRIPTION
ArgCheck 2.0 is only breaking in how it works together with OptionalArgChecks, so that shouldn't affect this package at all. Might be worth considering to setup CompatHelper for this repo, which would automatically create PRs in cases like this.