### PR TITLE
Fix bugs in multinomial sampling

### DIFF
--- a/.github/workflows/AHMC-CI.yml
+++ b/.github/workflows/AHMC-CI.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       matrix:
         version:

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -87,7 +87,13 @@ function step(
         else
             res = z
         end
-        !isfinite(z) && break
+        if !isfinite(z)
+            # Remove undef
+            if FullTraj
+                res = res[isassigned.(Ref(res), 1:n_steps)]
+            end
+            break
+        end
     end
     return res
 end

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -278,7 +278,7 @@ end
 # zs is in the form of Vector{PhasePoint{Matrix}} and has shape [n_steps][dim, n_chains]
 function randcat(rng, zs::AbstractVector{<:PhasePoint}, unnorm_ℓP::AbstractMatrix)
     z = similar(first(zs))
-    P = exp.(unnorm_ℓP .- logsumexp(unnorm_ℓP; dims=2)) # (n_chians, n_steps)
+    P = exp.(unnorm_ℓP .- logsumexp(unnorm_ℓP; dims=2)) # (n_chains, n_steps)
     is = randcat(rng, P')
     foreach(enumerate(is)) do (i_chain, i_step)
         zi = zs[i_step]

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -263,7 +263,6 @@ end
 
 function sample_phasepoint(rng, τ::StaticTrajectory{EndPointTS}, h, z)
     z′ = step(τ.integrator, h, z, τ.n_steps)
-    # Are we going to accept the `z′` via MH criteria?
     is_accept, α = mh_accept_ratio(rng, energy(z), energy(z′))
     return z′, is_accept, α
 end

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -294,9 +294,9 @@ end
 
 function sample_phasepoint(rng, τ::StaticTrajectory{MultinomialTS}, h, z)
     n_steps = abs(τ.n_steps)
-    # FIXME: deal with multi-chain generically.
-    #        Currently the direction of multiple chains are always coupled
-    n_steps_fwd = rand_sync(rng, 0:n_steps) 
+    # TODO: Deal with vectorized-mode generically.
+    #       Currently the direction of multiple chains are always coupled
+    n_steps_fwd = rand_coupled(rng, 0:n_steps) 
     zs_fwd = step(τ.integrator, h, z, n_steps_fwd; fwd=true, full_trajectory=Val(true))
     n_steps_bwd = n_steps - n_steps_fwd
     zs_bwd = step(τ.integrator, h, z, n_steps_bwd; fwd=false, full_trajectory=Val(true))

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -259,11 +259,7 @@ function accept_phasepoint!(z::T, z′::T, is_accept) where {T<:PhasePoint{<:Abs
     return z′
 end
 
-<<<<<<< HEAD
-### Use end-point from trajectory as proposal 
-=======
 ### Use end-point from the trajectory as a proposal and apply MH correction
->>>>>>> Apply suggestions from Hong
 
 function samplecand(rng, τ::StaticTrajectory{EndPointTS}, h, z)
     z′ = step(τ.integrator, h, z, τ.n_steps)
@@ -299,17 +295,10 @@ end
 
 function samplecand(rng, τ::StaticTrajectory{MultinomialTS}, h, z)
     n_steps = abs(τ.n_steps)
-<<<<<<< HEAD
     n_steps_fwd = rand(0:n_steps) # FIXME: deal with multi-chain generically
     zs_fwd = step(τ.integrator, h, z, n_steps_fwd; fwd=true, full_trajectory=Val(true))
     n_steps_bwd = n_steps - n_steps_fwd
     zs_bwd = step(τ.integrator, h, z, n_steps_bwd; fwd=false, full_trajectory=Val(true))
-=======
-    n_steps_fwd = rand(0:n_steps) # FIXME: deal with multi-chain generically
-    zs_fwd = step(τ.integrator, h, z, n_fwd; fwd=true, res=[z for _ in 1:n_fwd])
-    n_steps_bwd = n_steps - n_steps_fwd
-    zs_bwd = step(τ.integrator, h, z, n_bwd; fwd=false, res=[z for _ in 1:n_bwd])
->>>>>>> Apply suggestions from Hong
     zs = vcat(reverse(zs_bwd)..., z, zs_fwd...)
     ℓws = -energy.(zs)
     if eltype(ℓws) <: AbstractVector

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -309,12 +309,7 @@ function sample_phasepoint(rng, τ::StaticTrajectory{MultinomialTS}, h, z)
     Hs = -ℓweights
     ΔH = Hs .- energy(z)
     α = exp.(min.(0, -ΔH))  # this is a matrix for vectorized mode and a vector otherwise
-    α =
-    if typeof(α) <: AbstractVector
-        mean(α)
-    else
-        vec(mean(α; dims=2))
-    end
+    α = typeof(α) <: AbstractVector ? mean(α) : vec(mean(α; dims=2))
     return z′, true, α
 end
 

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -259,7 +259,11 @@ function accept_phasepoint!(z::T, z′::T, is_accept) where {T<:PhasePoint{<:Abs
     return z′
 end
 
+<<<<<<< HEAD
 ### Use end-point from trajectory as proposal 
+=======
+### Use end-point from the trajectory as a proposal and apply MH correction
+>>>>>>> Apply suggestions from Hong
 
 function samplecand(rng, τ::StaticTrajectory{EndPointTS}, h, z)
     z′ = step(τ.integrator, h, z, τ.n_steps)
@@ -295,10 +299,17 @@ end
 
 function samplecand(rng, τ::StaticTrajectory{MultinomialTS}, h, z)
     n_steps = abs(τ.n_steps)
-    n_fwd = rand(0:n_steps) # FIXME: deal with multi-chain generically
-    zs_fwd = step(τ.integrator, h, z, n_fwd; fwd=true, full_trajectory=Val(true))
-    n_bwd = n_steps - n_fwd
-    zs_bwd = step(τ.integrator, h, z, n_bwd; fwd=false, full_trajectory=Val(true))
+<<<<<<< HEAD
+    n_steps_fwd = rand(0:n_steps) # FIXME: deal with multi-chain generically
+    zs_fwd = step(τ.integrator, h, z, n_steps_fwd; fwd=true, full_trajectory=Val(true))
+    n_steps_bwd = n_steps - n_steps_fwd
+    zs_bwd = step(τ.integrator, h, z, n_steps_bwd; fwd=false, full_trajectory=Val(true))
+=======
+    n_steps_fwd = rand(0:n_steps) # FIXME: deal with multi-chain generically
+    zs_fwd = step(τ.integrator, h, z, n_fwd; fwd=true, res=[z for _ in 1:n_fwd])
+    n_steps_bwd = n_steps - n_steps_fwd
+    zs_bwd = step(τ.integrator, h, z, n_bwd; fwd=false, res=[z for _ in 1:n_bwd])
+>>>>>>> Apply suggestions from Hong
     zs = vcat(reverse(zs_bwd)..., z, zs_fwd...)
     ℓws = -energy.(zs)
     if eltype(ℓws) <: AbstractVector

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -213,7 +213,7 @@ function transition(
 )
     H0 = energy(z)
     integrator = jitter(rng, τ.integrator)
-    z′, is_accept, α = samplecand(rng, τ, h, z)
+    z′, is_accept, α = sample_phasepoint(rng, τ, h, z)
     # Do the actual accept / reject
     z = accept_phasepoint!(z, z′, is_accept)    # NOTE: this function changes `z′` in place in matrix-parallel mode
     # Reverse momentum variable to preserve reversibility
@@ -261,7 +261,7 @@ end
 
 ### Use end-point from the trajectory as a proposal and apply MH correction
 
-function samplecand(rng, τ::StaticTrajectory{EndPointTS}, h, z)
+function sample_phasepoint(rng, τ::StaticTrajectory{EndPointTS}, h, z)
     z′ = step(τ.integrator, h, z, τ.n_steps)
     # Are we going to accept the `z′` via MH criteria?
     is_accept, α = mh_accept_ratio(rng, energy(z), energy(z′))
@@ -293,7 +293,7 @@ function randcat(rng, zs::AbstractVector{<:PhasePoint}, unnorm_ℓP::AbstractMat
     return z
 end
 
-function samplecand(rng, τ::StaticTrajectory{MultinomialTS}, h, z)
+function sample_phasepoint(rng, τ::StaticTrajectory{MultinomialTS}, h, z)
     n_steps = abs(τ.n_steps)
     n_steps_fwd = rand(0:n_steps) # FIXME: deal with multi-chain generically
     zs_fwd = step(τ.integrator, h, z, n_steps_fwd; fwd=true, full_trajectory=Val(true))

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -294,7 +294,9 @@ end
 
 function sample_phasepoint(rng, τ::StaticTrajectory{MultinomialTS}, h, z)
     n_steps = abs(τ.n_steps)
-    n_steps_fwd = rand(0:n_steps) # FIXME: deal with multi-chain generically
+    # FIXME: deal with multi-chain generically.
+    #        Currently the direction of multiple chains are always coupled
+    n_steps_fwd = rand_sync(rng, 0:n_steps) 
     zs_fwd = step(τ.integrator, h, z, n_steps_fwd; fwd=true, full_trajectory=Val(true))
     n_steps_bwd = n_steps - n_steps_fwd
     zs_bwd = step(τ.integrator, h, z, n_steps_bwd; fwd=false, full_trajectory=Val(true))

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -279,7 +279,7 @@ end
 function randcat(rng, zs::AbstractVector{<:PhasePoint}, unnorm_ℓP::AbstractMatrix)
     z = similar(first(zs))
     P = exp.(unnorm_ℓP .- logsumexp(unnorm_ℓP; dims=2)) # (n_chians, n_steps)
-    is = randcat(rng, P)
+    is = randcat(rng, P')
     foreach(enumerate(is)) do (i_chain, i_step)
         zi = zs[i_step]
         z.θ[:,i_chain] = zi.θ[:,i_chain]

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -299,14 +299,14 @@ function sample_phasepoint(rng, τ::StaticTrajectory{MultinomialTS}, h, z)
     n_steps_bwd = n_steps - n_steps_fwd
     zs_bwd = step(τ.integrator, h, z, n_steps_bwd; fwd=false, full_trajectory=Val(true))
     zs = vcat(reverse(zs_bwd)..., z, zs_fwd...)
-    ℓws = -energy.(zs)
-    if eltype(ℓws) <: AbstractVector
-        ℓws = cat(ℓws...; dims=2)
+    ℓweights = -energy.(zs)
+    if eltype(ℓweights) <: AbstractVector
+        ℓweights = cat(ℓweights...; dims=2)
     end
-    unnorm_ℓprob = ℓws
+    unnorm_ℓprob = ℓweights
     z′ = randcat(rng, zs, unnorm_ℓprob)
     # Computing adaptation statistics for dual averaging as done in NUTS
-    Hs = -ℓws
+    Hs = -ℓweights
     ΔH = Hs .- energy(z)
     α = exp.(min.(0, -ΔH))  # this is a matrix for vectorized mode and a vector otherwise
     α =

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -16,14 +16,18 @@ function Base.randn(rng::AbstractVector{<:AbstractRNG}, T, dim::Int, n_chains::I
     return cat(randn.(rng, T, dim)...; dims=2)
 end
 
-# Helper functions to sync RNGs that ensures coupling works properly and reproducible
+""" 
+`rand_coupled` produces coupled randomness given a vector of RNGs.  For example, 
+when a vector of RNGs is provided, `rand_coupled` returns the same value for all RNGs
+and keep all RNGs synchronised.  This is important if we want to couple multiple Markov chains.
+"""
 
-rand_sync(rng::AbstractRNG, args...) = rand(rng, args...)
+rand_coupled(rng::AbstractRNG, args...) = rand(rng, args...)
 
 # This function is needed to use only one RNG while a vector of RNGs are provided
 # in a way that RNGs are still synchronised. This is important if we want to use 
 # same RNGs to couple multiple chains.
-function rand_sync(rngs::AbstractVector{<:AbstractRNG}, args...)
+function rand_coupled(rngs::AbstractVector{<:AbstractRNG}, args...)
     # Dummpy calles to sync RNGs
     foreach(rngs[2:end]) do rng
         rand(rng, args...)
@@ -80,6 +84,6 @@ function randcat(
 ) where {T}
     u = rand(rng, T, size(P, 2))
     C = cumsum(P; dims=1)
-    is = convert.(Int, vec(sum(C .< u'; dims=1))) .+ 1
-    return max.(is, 1)  # prevent numerical issue for Float32
+    indices = convert.(Int, vec(sum(C .< u'; dims=1))) .+ 1
+    return max.(indices, 1)  # prevent numerical issue for Float32
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -34,6 +34,6 @@ function randcat(
 ) where {T}
     u = rand(rng, T, size(P, 1))
     C = cumsum(P; dims=2)
-    is = convert.(Int, vec(sum(C .< u; dims=2)))
+    is = convert.(Int, vec(sum(C .< u; dims=2))) .+ 1
     return max.(is, 1)
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -72,7 +72,7 @@ Then `C .< u'` is
     0 0
 ]
 ```
-and thus should have `convert.(Int, vec(sum(C .< u'; dims=1))) .+ 1` equals `[1, 2]`.
+thus `convert.(Int, vec(sum(C .< u'; dims=1))) .+ 1` equals `[1, 2]`.
 """
 function randcat(
     rng::Union{AbstractRNG, AbstractVector{<:AbstractRNG}}, 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -28,12 +28,43 @@ function randcat(rng::AbstractRNG, p::AbstractVector{T}) where {T}
     return max(i, 1)
 end
 
+"""
+    randcat(rng, P::AbstractMatrix)
+
+Generating Categorical random variables in a vectorized mode.
+`P` is supposed to be a matrix of (D, N) where each column is a probability vector.
+
+Example
+
+```
+P = [
+    0.5 0.3;
+    0.4 0.6;
+    0.1 0.1
+]
+u = [0.3, 0.4]
+C = [
+    0.5 0.3
+    0.9 0.9
+    1.0 1.0
+]
+```
+Then `C .< u'` is
+```
+[
+    0 1
+    0 0
+    0 0
+]
+```
+and thus should have `convert.(Int, vec(sum(C .< u'; dims=1))) .+ 1` equals `[1, 2]`.
+"""
 function randcat(
     rng::Union{AbstractRNG, AbstractVector{<:AbstractRNG}}, 
     P::AbstractMatrix{T}
 ) where {T}
-    u = rand(rng, T, size(P, 1))
-    C = cumsum(P; dims=2)
-    is = convert.(Int, vec(sum(C .< u; dims=2))) .+ 1
-    return max.(is, 1)
+    u = rand(rng, T, size(P, 2))
+    C = cumsum(P; dims=1)
+    is = convert.(Int, vec(sum(C .< u'; dims=1))) .+ 1
+    return max.(is, 1)  # prevent numerical issue for Float32
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -17,16 +17,14 @@ function Base.randn(rng::AbstractVector{<:AbstractRNG}, T, dim::Int, n_chains::I
 end
 
 """ 
-`rand_coupled` produces coupled randomness given a vector of RNGs.  For example, 
-when a vector of RNGs is provided, `rand_coupled` returns the same value for all RNGs
-and keep all RNGs synchronised.  This is important if we want to couple multiple Markov chains.
+`rand_coupled` produces coupled randomness given a vector of RNGs. For example, 
+when a vector of RNGs is provided, `rand_coupled` peforms a single `rand` call 
+(rather than a `rand` call for each RNG) while keep all RNGs synchronised. 
+This is important if we want to couple multiple Markov chains.
 """
 
 rand_coupled(rng::AbstractRNG, args...) = rand(rng, args...)
 
-# This function is needed to use only one RNG while a vector of RNGs are provided
-# in a way that RNGs are still synchronised. This is important if we want to use 
-# same RNGs to couple multiple chains.
 function rand_coupled(rngs::AbstractVector{<:AbstractRNG}, args...)
     # Dummpy calles to sync RNGs
     foreach(rngs[2:end]) do rng

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -18,9 +18,6 @@ end
 
 # Sample from Categorical distributions
 
-randcat_logp(rng::AbstractRNG, unnorm_ℓp::AbstractVector) =
-    randcat(rng, exp.(unnorm_ℓp .- logsumexp(unnorm_ℓp)))
-
 function randcat(rng::AbstractRNG, p::AbstractVector{T}) where {T}
     u = rand(rng, T)
     c = zero(eltype(p))
@@ -30,11 +27,6 @@ function randcat(rng::AbstractRNG, p::AbstractVector{T}) where {T}
     end
     return max(i, 1)
 end
-
-randcat_logp(
-    rng::Union{AbstractRNG, AbstractVector{<:AbstractRNG}}, 
-    unnorm_ℓP::AbstractMatrix
-) = randcat(rng, exp.(unnorm_ℓP .- logsumexp(unnorm_ℓP; dims=2)))
 
 function randcat(
     rng::Union{AbstractRNG, AbstractVector{<:AbstractRNG}}, 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -16,6 +16,20 @@ function Base.randn(rng::AbstractVector{<:AbstractRNG}, T, dim::Int, n_chains::I
     return cat(randn.(rng, T, dim)...; dims=2)
 end
 
+# Helper functions to sync RNGs
+
+rand_sync(rng::AbstractRNG, args...) = rand(rng, args...)
+
+# This function is needed to use only one RNG while a vector of RNGs are provided
+# in a way that RNGs are still synchronised.
+function rand_sync(rngs::AbstractVector{<:AbstractRNG}, args...)
+    # Dummpy calles to sync RNGs
+    foreach(rngs[2:end]) do rng
+        rand(rng, args...)
+    end
+    return res = rand(first(rngs), args...)
+end
+
 # Sample from Categorical distributions
 
 function randcat(rng::AbstractRNG, p::AbstractVector{T}) where {T}

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -16,12 +16,13 @@ function Base.randn(rng::AbstractVector{<:AbstractRNG}, T, dim::Int, n_chains::I
     return cat(randn.(rng, T, dim)...; dims=2)
 end
 
-# Helper functions to sync RNGs
+# Helper functions to sync RNGs that ensures coupling works properly and reproducible
 
 rand_sync(rng::AbstractRNG, args...) = rand(rng, args...)
 
 # This function is needed to use only one RNG while a vector of RNGs are provided
-# in a way that RNGs are still synchronised.
+# in a way that RNGs are still synchronised. This is important if we want to use 
+# same RNGs to couple multiple chains.
 function rand_sync(rngs::AbstractVector{<:AbstractRNG}, args...)
     # Dummpy calles to sync RNGs
     foreach(rngs[2:end]) do rng


### PR DESCRIPTION
There are a few bugs in the multinomial trajectory sampling

1. There is an extra MH correction step (https://github.com/TuringLang/AdvancedHMC.jl/issues/198) that should be removed.
2. The way trajectory got sampled is wrong. The correct way is randomly expanding on both directions.
3. `randcat` for matrix has a typo that ended up shifting the samples by 1. This only influences the vectorized mode.