### PR TITLE
Small changes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.2.24"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 InplaceOps = "505f98c9-085e-5b2c-8e89-488be7bf1f34"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"

--- a/src/AdvancedHMC.jl
+++ b/src/AdvancedHMC.jl
@@ -10,6 +10,8 @@ using ProgressMeter: ProgressMeter
 using Parameters: @unpack, reconstruct
 using ArgCheck: @argcheck
 
+using DocStringExtensions: TYPEDEF, TYPEDFIELDS
+
 import StatsBase: sample
 import Parameters: reconstruct
 

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -7,6 +7,17 @@
 # We might want to simplify it to `Tuple{Int,Bool}` when we figured out
 # why the it behaves unexpected on Windos 32.
 
+"""
+$(TYPEDEF)
+
+Represents an integrator used to simulate the Hamiltonian system.
+
+# Implementation
+A `AbstractIntegrator` is expected to have the following implementations:
+- `stat`(@ref)
+- `nom_step_size`(@ref)
+- `step_size`(@ref)
+"""
 abstract type AbstractIntegrator end
 
 stat(::AbstractIntegrator) = NamedTuple()

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -59,7 +59,7 @@ function step(
     ϵ = ϵ'
 
     res = if FullTraj
-        Vector{typeof(z)}(undef, n_steps)
+        Vector{P}(undef, n_steps)
     else
         z
     end

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -81,7 +81,17 @@ function step(
     return res
 end
 
+"""
+$(TYPEDEF)
+
+Leapfrog integrator with fixed step size `ϵ`.
+
+# Fields
+
+$(TYPEDFIELDS)
+"""
 struct Leapfrog{T<:AbstractScalarOrVec{<:AbstractFloat}} <: AbstractLeapfrog{T}
+    "Step size."
     ϵ       ::  T
 end
 Base.show(io::IO, l::Leapfrog) = print(io, "Leapfrog(ϵ=$(round.(l.ϵ; sigdigits=3)))")
@@ -91,17 +101,29 @@ Base.show(io::IO, l::Leapfrog) = print(io, "Leapfrog(ϵ=$(round.(l.ϵ; sigdigits
 """
 $(TYPEDEF)
 
-Randomly "jitters" the step size at the beginning of each trajectory.
+Leapfrog integrator with randomly "jittered" step size `ϵ` for every trajectory.
 
 # Fields
 
 $(TYPEDFIELDS)
 
 # Description
-
-This might help alleviate issues related to poor interactions with a fixed step size, such as:
-- In regions with high "curvature" the current choice of step size might mean over-shoot leading to almost all steps being rejected. Randomly sampling the step size at the beginning of the trajectories can therefore increase the probability of escaping such high-curvature regions.
-- Exact periodicity of the simulated trajectories might occur, i.e. you might be so unlucky as to simulate the trajectory forwards in time `L ϵ` and ending up at the same point (which results in non-ergodicity; see Section 3.2 in [1]). If momentum is refreshed before each trajectory, then this should not happen *exactly* but it can still be an issue in practice. Randomly choosing the step-size `ϵ` might help alleviate such problems.
+This is the same as `LeapFrog`(@ref) but with a "jittered" step size. This means 
+that at the beginning of each trajectory we sample a step size `ϵ` by adding or 
+subtracting from the nominal/base step size `ϵ0` some random proportion of `ϵ0`, 
+with the proportion specified by `jitter`, i.e. `ϵ = ϵ0 - jitter * ϵ0 * rand()`.
+p
+Jittering might help alleviate issues related to poor interactions with a fixed step size:
+- In regions with high "curvature" the current choice of step size might mean over-shoot 
+  leading to almost all steps being rejected. Randomly sampling the step size at the 
+  beginning of the trajectories can therefore increase the probability of escaping such
+  high-curvature regions.
+- Exact periodicity of the simulated trajectories might occur, i.e. you might be so
+  unlucky as to simulate the trajectory forwards in time `L ϵ` and ending up at the
+  same point (which results in non-ergodicity; see Section 3.2 in [1]). If momentum
+  is refreshed before each trajectory, then this should not happen *exactly* but it
+  can still be an issue in practice. Randomly choosing the step-size `ϵ` might help
+  alleviate such problems.
 
 # References
 1. Neal, R. M. (2011). MCMC using Hamiltonian dynamics. Handbook of Markov chain Monte Carlo, 2(11), 2. ([arXiv](https://arxiv.org/pdf/1206.1901))
@@ -140,9 +162,25 @@ jitter(
 ) where {FT<:AbstractFloat,T<:AbstractScalarOrVec{FT}} = _jitter(rng, lf)
 
 ### Tempering
+# TODO: add ref or at least explain what exactly we're doing
+"""
+$(TYPEDEF)
 
+Tempered leapfrog integrator with fixed step size `ϵ` and "temperature" `α`.
+
+# Fields
+
+$(TYPEDFIELDS)
+
+# Description
+
+Tempering can potentially allow greater exploration of the posterior, e.g. 
+in a multi-modal posterior jumps between the modes can be more likely to occur.
+"""
 struct TemperedLeapfrog{FT<:AbstractFloat,T<:AbstractScalarOrVec{FT}} <: AbstractLeapfrog{T}
+    "Step size."
     ϵ       ::  T
+    "Temperature parameter."
     α       ::  FT
 end
 

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -88,10 +88,31 @@ Base.show(io::IO, l::Leapfrog) = print(io, "Leapfrog(ϵ=$(round.(l.ϵ; sigdigits
 
 ### Jittering
 
+"""
+$(TYPEDEF)
+
+Randomly "jitters" the step size at the beginning of each trajectory.
+
+# Fields
+
+$(TYPEDFIELDS)
+
+# Description
+
+This might help alleviate issues related to poor interactions with a fixed step size, such as:
+- In regions with high "curvature" the current choice of step size might mean over-shoot leading to almost all steps being rejected. Randomly sampling the step size at the beginning of the trajectories can therefore increase the probability of escaping such high-curvature regions.
+- Exact periodicity of the simulated trajectories might occur, i.e. you might be so unlucky as to simulate the trajectory forwards in time `L ϵ` and ending up at the same point (which results in non-ergodicity; see Section 3.2 in [1]). If momentum is refreshed before each trajectory, then this should not happen *exactly* but it can still be an issue in practice. Randomly choosing the step-size `ϵ` might help alleviate such problems.
+
+# References
+1. Neal, R. M. (2011). MCMC using Hamiltonian dynamics. Handbook of Markov chain Monte Carlo, 2(11), 2. ([arXiv](https://arxiv.org/pdf/1206.1901))
+"""
 struct JitteredLeapfrog{FT<:AbstractFloat,T<:AbstractScalarOrVec{FT}} <: AbstractLeapfrog{T}
-    ϵ0      ::  T  # nominal (unjittered) step size
+    "Nominal (non-jittered) step size."
+    ϵ0      ::  T
+    "The proportion of the nominal step size `ϵ0` that may be added or subtracted."
     jitter  ::  FT
-    ϵ       ::  T  # current (jittered) step size
+    "Current (jittered) step size."
+    ϵ       ::  T
 end
 
 JitteredLeapfrog(ϵ0, jitter) = JitteredLeapfrog(ϵ0, jitter, ϵ0)

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -142,7 +142,7 @@ function transition(τ::AbstractTrajectory, h::Hamiltonian, z::PhasePoint)
 end
 
 ###
-### Actual trajecory implementations
+### Actual trajectory implementations
 ###
 
 ###
@@ -246,7 +246,7 @@ function randcat(rng, zs::AbstractVector{<:PhasePoint}, unnorm_ℓP::AbstractMat
 end
 
 function samplecand(rng, τ::StaticTrajectory{MultinomialTS}, h, z)
-    zs = step(τ.integrator, h, z, τ.n_steps; res=[z for _ in 1:abs(τ.n_steps)])
+    zs = step(τ.integrator, h, z, τ.n_steps; full_trajectory = Val(true))
     ℓws = -energy.(zs)
     if eltype(ℓws) <: AbstractVector
         ℓws = hcat(ℓws...)


### PR DESCRIPTION
Currently going through the code and making some suggestions for small changes as I do.

It's mostly just docstrings, with the exception of an implementation change to `step` where I've replaced what would usually look like `step(...; res = [z for _ = 1:n_steps])` with `step(...; full_trajectory = Val(true))`. 

## Up for discussion
- Maybe just make it `step(...; full_trajectory::Bool = false)` instead? Julia's constant propagation should compile it away in the cases that we use it anyways since it's always hard-coded into the method depending on what it needs. 