### PR TITLE
Add robust U-turn check

### DIFF
--- a/src/AdvancedHMC.jl
+++ b/src/AdvancedHMC.jl
@@ -38,6 +38,7 @@ include("trajectory.jl")
 export EndPointTS, SliceTS, MultinomialTS, 
        StaticTrajectory, HMCDA, NUTS, 
        ClassicNoUTurn, GeneralisedNoUTurn, 
+       StrictGeneralisedNoUTurn,
        find_good_stepsize
 
 include("adaptation/Adaptation.jl")

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -602,11 +602,8 @@ end
 
 """
     isterminated(
-        h::Hamiltonian, 
-        t::BinaryTree{<:T},
-        tleft::BinaryTree{<:T}, 
-        tright::BinaryTree{<:T}
-    ) where {T<:StrictGeneralisedNoUTurn}
+        h::Hamiltonian, t::T, tleft::T, tright::T
+    ) where {T<:BinaryTree{<:StrictGeneralisedNoUTurn}}
 
 Detect U turn for two phase points (`zleft` and `zright`) under given Hamiltonian `h`
 using the generalised no-U-turn criterion with additional U-turn checks.
@@ -614,11 +611,8 @@ using the generalised no-U-turn criterion with additional U-turn checks.
 Ref: https://arxiv.org/abs/1701.02434 https://github.com/stan-dev/stan/pull/2800
 """
 function isterminated(
-    h::Hamiltonian, 
-    t::BinaryTree{<:StrictGeneralisedNoUTurn}, 
-    tleft::BinaryTree{<:StrictGeneralisedNoUTurn}, 
-    tright::BinaryTree{<:StrictGeneralisedNoUTurn}
-) 
+    h::Hamiltonian, t::T, tleft::T, tright::T
+) where {T<:BinaryTree{<:StrictGeneralisedNoUTurn}}
     # Classic generalised U-turn check
     t_generalised = BinaryTree(
         t.zleft,
@@ -640,21 +634,15 @@ end
 
 """
     check_left_subtree(
-        h::Hamiltonian, 
-        t::BinaryTree{<:StrictGeneralisedNoUTurn}, 
-        tleft::BinaryTree{<:StrictGeneralisedNoUTurn}, 
-        tright::BinaryTree{<:StrictGeneralisedNoUTurn}
-    )
+        h::Hamiltonian, t::T, tleft::T, tright::T
+    ) where {T<:BinaryTree{<:StrictGeneralisedNoUTurn}}
 
 Do a U-turn check between the leftmost phase point of `t` and the leftmost 
 phase point of `tright`, the right subtree.
 """
 function check_left_subtree(
-    h::Hamiltonian, 
-    t::BinaryTree{<:StrictGeneralisedNoUTurn}, 
-    tleft::BinaryTree{<:StrictGeneralisedNoUTurn}, 
-    tright::BinaryTree{<:StrictGeneralisedNoUTurn}
-)
+    h::Hamiltonian, t::T, tleft::T, tright::T
+) where {T<:BinaryTree{<:StrictGeneralisedNoUTurn}}
     rho = tleft.c.rho + tright.zleft.r
     s = generalised_uturn_criterion(rho, ∂H∂r(h, t.zleft.r), ∂H∂r(h, tright.zleft.r))
     return Termination(s, false)
@@ -662,21 +650,15 @@ end
 
 """
     check_left_subtree(
-        h::Hamiltonian, 
-        t::BinaryTree{<:StrictGeneralisedNoUTurn}, 
-        tleft::BinaryTree{<:StrictGeneralisedNoUTurn}, 
-        tright::BinaryTree{<:StrictGeneralisedNoUTurn}
-    )
+        h::Hamiltonian, t::T, tleft::T, tright::T
+    ) where {T<:BinaryTree{<:StrictGeneralisedNoUTurn}}
 
 Do a U-turn check between the rightmost phase point of `t` and the rightmost
 phase point of `tleft`, the left subtree.
 """
 function check_right_subtree(
-    h::Hamiltonian, 
-    t::BinaryTree{<:StrictGeneralisedNoUTurn}, 
-    tleft::BinaryTree{<:StrictGeneralisedNoUTurn}, 
-    tright::BinaryTree{<:StrictGeneralisedNoUTurn}
-)
+    h::Hamiltonian, t::T, tleft::T, tright::T
+) where {T<:BinaryTree{<:StrictGeneralisedNoUTurn}}
     rho = tleft.zright.r + tright.c.rho
     s = generalised_uturn_criterion(rho, ∂H∂r(h, tleft.zright.r), ∂H∂r(h, t.zright.r))
     return Termination(s, false)

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -427,7 +427,6 @@ struct StrictGeneralisedNoUTurn{T<:AbstractVector{<:Real}} <: AbstractTerminatio
 end
 
 StrictGeneralisedNoUTurn(z::PhasePoint) = StrictGeneralisedNoUTurn(z.r)
-convert(GeneralisedNoUTurn, c::StrictGeneralisedNoUTurn) = GeneralisedNoUTurn(c.rho)
 
 combine(::ClassicNoUTurn, ::ClassicNoUTurn) = ClassicNoUTurn()
 combine(cleft::T, cright::T) where {T<:GeneralisedNoUTurn} = T(cleft.rho + cright.rho)

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -593,8 +593,6 @@ function isterminated(
     tleft::BinaryTree{<:GeneralisedNoUTurn}, 
     tright::BinaryTree{<:GeneralisedNoUTurn}
 )
-    # z0 is starting point and z1 is ending point
-    z0, z1 = t.zleft, t.zright
     rho = t.c.rho
     s1 = generalised_uturn_criterion(rho, ∂H∂r(h, t.zleft.r), ∂H∂r(h, t.zright.r))
 


### PR DESCRIPTION
This addresses  #94 and adds the additional U-turn checks. 

The tests still need to be updated but I wanted to get some feedback first whether the general approach here makes sense.
The additional U-turn checks need more information about the tree structure so I had to alter the `BinaryTree` type to keep track of more phase points.