### PR TITLE
Fix adaptation of nominal step size for JitteredLeapfrog

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedHMC"
 uuid = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
-version = "0.2.25"
+version = "0.2.26"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -172,7 +172,7 @@ end
 
 nom_step_size(lf::JitteredLeapfrog) = lf.ϵ0
 
-update_nom_step_size(lf::JitteredLeapfrog, ϵ0) = reconstruct(lf, ϵ0=ϵ0, ϵ=ϵ0)
+update_nom_step_size(lf::JitteredLeapfrog, ϵ0) = reconstruct(lf, ϵ0=ϵ0)
 
 # Jitter step size; ref: https://github.com/stan-dev/stan/blob/1bb054027b01326e66ec610e95ef9b2a60aa6bec/src/stan/mcmc/hmc/base_hmc.hpp#L177-L178
 function _jitter(

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -38,12 +38,22 @@ Get the current integration step size.
 """
 function step_size end
 
+"""
+    update_nom_step_size(i::AbstractIntegrator, ϵ) -> AbstractIntegrator
+
+Return a copy of the integrator `i` with the new nominal step size ([`nom_step_size`](@ref))
+`ϵ`.
+"""
+function update_nom_step_size end
+
 abstract type AbstractLeapfrog{T} <: AbstractIntegrator end
 
 step_size(lf::AbstractLeapfrog) = lf.ϵ
 jitter(::Union{AbstractRNG, AbstractVector{<:AbstractRNG}}, lf::AbstractLeapfrog) = lf
 temper(lf::AbstractLeapfrog, r, ::NamedTuple{(:i, :is_half),<:Tuple{Integer,Bool}}, ::Int) = r
 stat(lf::AbstractLeapfrog) = (step_size=step_size(lf), nom_step_size=nom_step_size(lf))
+
+update_nom_step_size(lf::AbstractLeapfrog, ϵ) = reconstruct(lf, ϵ=ϵ)
 
 function step(
     lf::AbstractLeapfrog{T},
@@ -161,6 +171,8 @@ function Base.show(io::IO, l::JitteredLeapfrog)
 end
 
 nom_step_size(lf::JitteredLeapfrog) = lf.ϵ0
+
+update_nom_step_size(lf::JitteredLeapfrog, ϵ0) = reconstruct(lf, ϵ0=ϵ0, ϵ=ϵ0)
 
 # Jitter step size; ref: https://github.com/stan-dev/stan/blob/1bb054027b01326e66ec610e95ef9b2a60aa6bec/src/stan/mcmc/hmc/base_hmc.hpp#L177-L178
 function _jitter(

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -13,8 +13,7 @@ function reconstruct(
     τ::AbstractProposal, adaptor::Union{StepSizeAdaptor, NaiveHMCAdaptor, StanHMCAdaptor}
 )
     # FIXME: this does not support change type of `ϵ` (e.g. Float to Vector)
-    # FIXME: this is buggy for `JitteredLeapfrog`
-    integrator = reconstruct(τ.integrator, ϵ=getϵ(adaptor))
+    integrator = update_nom_step_size(τ.integrator, getϵ(adaptor))
     return reconstruct(τ, integrator=integrator)
 end
 

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -212,7 +212,10 @@ function transition(
     z::PhasePoint,
 )
     H0 = energy(z)
+
     integrator = jitter(rng, τ.integrator)
+    τ = reconstruct(τ, integrator=integrator)
+
     z′, is_accept, α = sample_phasepoint(rng, τ, h, z)
     # Do the actual accept / reject
     z = accept_phasepoint!(z, z′, is_accept)    # NOTE: this function changes `z′` in place in matrix-parallel mode

--- a/test/integrator.jl
+++ b/test/integrator.jl
@@ -67,6 +67,30 @@ end
     end
 end
 
+@testset "update_nom_step_size" begin
+    @testset "Leapfrog" begin
+        ϵ0 = 0.1
+        lf = Leapfrog(ϵ0)
+        @test AdvancedHMC.nom_step_size(lf) == ϵ0
+
+        lf2 = AdvancedHMC.update_nom_step_size(lf, 0.5)
+        @test lf2 !== lf
+        @test AdvancedHMC.nom_step_size(lf2) == 0.5
+        @test AdvancedHMC.step_size(lf2) == 0.5
+    end
+
+    @testset "JitteredLeapfrog" begin
+        ϵ0 = 0.1
+        lf = JitteredLeapfrog(ϵ0, 0.5)
+        @test AdvancedHMC.nom_step_size(lf) == ϵ0
+
+        lf2 = AdvancedHMC.update_nom_step_size(lf, 0.2)
+        @test lf2 !== lf
+        @test AdvancedHMC.nom_step_size(lf2) == 0.2
+        @test AdvancedHMC.step_size(lf2) == 0.2
+    end
+end
+
 @testset "temper" begin
     αsqrt = 2.0
     lf = TemperedLeapfrog(ϵ, αsqrt ^ 2)

--- a/test/integrator.jl
+++ b/test/integrator.jl
@@ -87,7 +87,8 @@ end
         lf2 = AdvancedHMC.update_nom_step_size(lf, 0.2)
         @test lf2 !== lf
         @test AdvancedHMC.nom_step_size(lf2) == 0.2
-        @test AdvancedHMC.step_size(lf2) == 0.2
+        # check that we've only updated nominal step size
+        @test AdvancedHMC.step_size(lf2) == ϵ0
     end
 end
 

--- a/test/integrator.jl
+++ b/test/integrator.jl
@@ -38,14 +38,33 @@ end
 # end
 
 @testset "jitter" begin
-    ϵ0 = 0.1
-    lf = JitteredLeapfrog(ϵ0, 0.5)
-    @test lf.ϵ0 == ϵ0
-    @test lf.ϵ == ϵ0
+    @testset "Leapfrog" begin
+        ϵ0 = 0.1
+        lf = Leapfrog(ϵ0)
+        @test lf.ϵ == ϵ0
+        @test AdvancedHMC.nom_step_size(lf) == ϵ0
+        @test AdvancedHMC.step_size(lf) == ϵ0
 
-    lf2 = AdvancedHMC.jitter(Random.GLOBAL_RNG, lf)
-    @test lf2.ϵ0 == ϵ0
-    @test lf2.ϵ != ϵ0
+        lf2 = AdvancedHMC.jitter(Random.GLOBAL_RNG, lf)
+        @test lf2 === lf
+        @test AdvancedHMC.nom_step_size(lf2) == ϵ0
+        @test AdvancedHMC.step_size(lf2) == ϵ0
+    end
+
+    @testset "JitteredLeapfrog" begin
+        ϵ0 = 0.1
+        lf = JitteredLeapfrog(ϵ0, 0.5)
+        @test lf.ϵ0 == ϵ0
+        @test AdvancedHMC.nom_step_size(lf) == ϵ0
+        @test lf.ϵ == ϵ0
+        @test AdvancedHMC.step_size(lf) == lf.ϵ
+
+        lf2 = AdvancedHMC.jitter(Random.GLOBAL_RNG, lf)
+        @test lf2.ϵ0 == ϵ0
+        @test AdvancedHMC.nom_step_size(lf2) == ϵ0
+        @test lf2.ϵ != ϵ0
+        @test AdvancedHMC.step_size(lf2) == lf2.ϵ
+    end
 end
 
 @testset "temper" begin


### PR DESCRIPTION
This PR fixes #218 using @xukai92's suggestion in https://github.com/TuringLang/AdvancedHMC.jl/issues/218#issuecomment-707167450.

Here's what we get for @Red-Portal's failing example in https://github.com/TuringLang/AdvancedHMC.jl/issues/218#issuecomment-703066979:

```julia
using AdvancedHMC, Distributions, ForwardDiff, Plots

D = 10; initial_θ = rand(D)
ℓπ(θ) = logpdf(MvNormal(zeros(D), ones(D)), θ)
n_samples, n_adapts = 2_000, 1_000

metric = DiagEuclideanMetric(D)
hamiltonian = Hamiltonian(metric, ℓπ, ForwardDiff)

# Leapfrog with 10% Jitter
integrator = JitteredLeapfrog(2.0, 0.1)

proposal = StaticTrajectory(integrator, 4)
adaptor = StanHMCAdaptor(MassMatrixAdaptor(metric), StepSizeAdaptor(0.8, integrator))

samples, stats = sample(hamiltonian, proposal, initial_θ, n_samples, adaptor, n_adapts; progress=true)

# Plot adaptation of stepsize 
Plots.plot([stat[:step_size] for stat in stats])
```
![step_size](https://user-images.githubusercontent.com/8673634/96055594-54966800-0e39-11eb-930b-1b6901a65f5f.png)

```julia
Plots.plot([stat[:nom_step_size] for stat in stats])
```
![nom_step_size](https://user-images.githubusercontent.com/8673634/96055618-61b35700-0e39-11eb-80d2-7717f571a707.png)
