### PR TITLE
Run Github Actions CI on latest release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.3'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
The compatibility errors in #220 appear to come from restrictions to the julia version for some test dependency. This PR updates the Github Actions CI to use the latest release of Julia, same as Travis. 