### PR TITLE
[WIP] Implement an iterative NUTS algorithm

### DIFF
--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -854,6 +854,7 @@ function transition(
     while !isterminated(termination) && j < τ.max_depth
         # Sample a direction; `-1` means left and `1` means right
         v = rand(rng, [-1, 1])
+        # TODO: vectorize this branch
         if v == -1
             # Create a tree with depth `j` on the left
             tree′, sampler′, termination′ = build_tree(rng, τ, h, tree.zleft, sampler, v, j, H0)
@@ -864,6 +865,7 @@ function transition(
             treeleft, treeright = tree, tree′
         end
         # Perform a MH step and increse depth if not terminated
+        # TODO: vectorize this branch
         if !isterminated(termination′)
             j = j + 1   # increment tree depth
             if mh_accept(rng, sampler, sampler′)

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -726,6 +726,18 @@ function build_two_leaf_tree(rng, nt::NUTS, h, z, sampler, v, H0)
 end
 
 """
+    subtree_cache_combine_range(ileaf::Integer) -> UnitRange
+
+Get the indices of the cached trees that need to be combined with the two-leaf tree produced
+at even leaf number `ileaf`.
+"""
+@inline function subtree_cache_combine_range(ileaf)
+    imin = count_ones(ileaf)
+    inum = trailing_zeros(ileaf)
+    return (imin + inum - 2):-1:imin
+end
+
+"""
 Recursivly build a tree for a given depth `j`.
 """
 function build_tree(


### PR DESCRIPTION
As discussed in #140, the recursion in the `build_tree` function used for NUTS algorithm is problematic for vectorization. This PR introduces an iterative `build_tree` function that is equivalent to the recursive one.

To facilitate comparison while working on this PR, I have added a type parameter to the signature of `NUTS` to indicate whether to use recursion or iteration. This is used for benchmarking and regression tests. My intention if this is accepted is to revert that commit and delete the recursive `build_tree`, making iterative NUTS the default.

In preliminary benchmarks, the iterative and recursive versions are similar in runtime, allocations, and memory usage. However, for some target distributions, one may be slightly faster than the other. As this gets further along, I'll add more rigorous benchmarks. However, all regression tests currently pass, and reviews are welcome.