### PR TITLE
Fixed default type for NesterovDualAveraging

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedHMC"
 uuid = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
-version = "0.2.27"
+version = "0.2.28"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/adaptation/stepsize.jl
+++ b/src/adaptation/stepsize.jl
@@ -86,10 +86,11 @@ NesterovDualAveraging(
     δ::T,
     ϵ::VT
 ) where {T<:AbstractFloat, VT<:AbstractScalarOrVec{T}} = NesterovDualAveraging(γ, t_0, κ, δ, DAState(ϵ))
+
 NesterovDualAveraging(
     δ::T,
     ϵ::VT
-) where {T<:AbstractFloat, VT<:AbstractScalarOrVec{T}} = NesterovDualAveraging(0.05, 10.0, 0.75, δ, ϵ)
+) where {T<:AbstractFloat, VT<:AbstractScalarOrVec{T}} = NesterovDualAveraging(T(0.05), T(10.0), T(0.75), δ, ϵ)
 
 # Ref: https://github.com/stan-dev/stan/blob/develop/src/stan/mcmc/stepsize_adaptation.hpp
 # Note: This function is not merged with `adapt!` to empahsize the fact that


### PR DESCRIPTION
`NesterovDualAveraging` has a default constructor which does not respect the types of the given parameters. This PR fixes this. 

Note that `δ` and the rest of the parameters now wrapped with `T` are required to have the same type, and so the current constructor simply fails if `δ` is a `Float32`.