### PR TITLE
Introduce HMCKernel and momentum refreshment structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ All the combinations are tested in [this file](https://github.com/TuringLang/Adv
 function sample(
     rng::Union{AbstractRNG, AbstractVector{<:AbstractRNG}},
     h::Hamiltonian,
-    τ::AbstractProposal,
+    κ::HMCKernel,
     θ::AbstractVector{<:AbstractFloat},
     n_samples::Int,
     adaptor::AbstractAdaptor=NoAdaptation(),
@@ -149,7 +149,7 @@ function sample(
 )
 ```
 
-Draw `n_samples` samples using the proposal `τ` under the Hamiltonian system `h`
+Draw `n_samples` samples using the proposal `κ` under the Hamiltonian system `h`
 
 - The randomness is controlled by `rng`.
   - If `rng` is not provided, `GLOBAL_RNG` will be used.

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -138,14 +138,14 @@ phasepoint(
     h::Hamiltonian
 ) where {T<:Real} = phasepoint(h, θ, rand(rng, h.metric))
 
-abstract type AbstractRefreshment end
+abstract type AbstractMomentumRefreshment end
 
 "Completly resample new momentum."
-struct FullRefreshment <: AbstractRefreshment end
+struct FullMomentumRefreshment <: AbstractMomentumRefreshment end
 
 refresh(
     rng::Union{AbstractRNG, AbstractVector{<:AbstractRNG}},
-    ::FullRefreshment,
+    ::FullMomentumRefreshment,
     h::Hamiltonian,
     z::PhasePoint,
 ) = phasepoint(h, z.θ, rand(rng, h.metric))
@@ -157,13 +157,13 @@ Partial momentum refreshment with refresh rate `α`.
 
 1. Neal, Radford M. "MCMC using Hamiltonian dynamics." Handbook of markov chain monte carlo 2.11 (2011): 2.
 """
-struct PartialRefreshment{F<:AbstractFloat} <: AbstractRefreshment
+struct PartialMomentumRefreshment{F<:AbstractFloat} <: AbstractMomentumRefreshment
     α::F
 end
 
 refresh(
     rng::Union{AbstractRNG, AbstractVector{<:AbstractRNG}},
-    ref::PartialRefreshment,
+    ref::PartialMomentumRefreshment,
     h::Hamiltonian,
     z::PhasePoint,
 ) = phasepoint(h, z.θ, ref.α * z.r + (1 - ref.α^2) * rand(rng, h.metric))

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -138,15 +138,32 @@ phasepoint(
     h::Hamiltonian
 ) where {T<:Real} = phasepoint(h, θ, rand(rng, h.metric))
 
+abstract type AbstractRefreshment end
+
+"Completly resample new momentum."
+struct FullRefreshment <: AbstractRefreshment end
+
 refresh(
     rng::Union{AbstractRNG, AbstractVector{<:AbstractRNG}},
+    ::FullRefreshment,
+    h::Hamiltonian,
     z::PhasePoint,
-    h::Hamiltonian
 ) = phasepoint(h, z.θ, rand(rng, h.metric))
 
-# refresh(
-#     rng::Union{AbstractRNG, AbstractVector{<:AbstractRNG}},
-#     z::PhasePoint,
-#     h::Hamiltonian,
-#     α::AbstractFloat
-# ) = phasepoint(h, z.θ, α * z.r + (1 - α^2) * rand(rng, h.metric))
+"""
+Partial momentum refreshment with refresh rate `α`.
+
+## References
+
+1. Neal, Radford M. "MCMC using Hamiltonian dynamics." Handbook of markov chain monte carlo 2.11 (2011): 2.
+"""
+struct PartialRefreshment{F<:AbstractFloat} <: AbstractRefreshment
+    α::F
+end
+
+refresh(
+    rng::Union{AbstractRNG, AbstractVector{<:AbstractRNG}},
+    ref::PartialRefreshment,
+    h::Hamiltonian,
+    z::PhasePoint,
+) = phasepoint(h, z.θ, ref.α * z.r + (1 - ref.α^2) * rand(rng, h.metric))

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -156,7 +156,7 @@ Sample `n_samples` samples using the proposal `κ` under Hamiltonian `h`.
 function sample(
     rng::Union{AbstractRNG, AbstractVector{<:AbstractRNG}},
     h::Hamiltonian,
-    κ::AbstractMCMCKernel,
+    κ::HMCKernel,
     θ::T,
     n_samples::Int,
     adaptor::AbstractAdaptor=NoAdaptation(),

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -8,14 +8,17 @@ function reconstruct(
     return reconstruct(h, metric=metric)
 end
 
-reconstruct(τ::AbstractProposal, ::AbstractAdaptor) = τ
+reconstruct(τ::Trajectory, ::AbstractAdaptor) = τ
 function reconstruct(
-    τ::AbstractProposal, adaptor::Union{StepSizeAdaptor, NaiveHMCAdaptor, StanHMCAdaptor}
+    τ::Trajectory, adaptor::Union{StepSizeAdaptor, NaiveHMCAdaptor, StanHMCAdaptor}
 )
     # FIXME: this does not support change type of `ϵ` (e.g. Float to Vector)
     integrator = update_nom_step_size(τ.integrator, getϵ(adaptor))
     return reconstruct(τ, integrator=integrator)
 end
+
+reconstruct(κ::AbstractMCMCKernel, adaptor::AbstractAdaptor) = 
+    reconstruct(κ, τ=reconstruct(κ.τ, adaptor))
 
 function resize(h::Hamiltonian, θ::AbstractVecOrMat{T}) where {T<:AbstractFloat}
     metric = h.metric
@@ -42,32 +45,31 @@ function sample_init(
     return h, t
 end
 
-# A step is a momentum refreshment plus a transition
-function step(
+function transition(
     rng::Union{AbstractRNG, AbstractVector{<:AbstractRNG}}, 
     h::Hamiltonian, 
-    τ::AbstractProposal, 
-    z::PhasePoint
+    κ::HMCKernel,
+    z::PhasePoint,
 )
-    # Refresh momentum
-    z = refresh(rng, z, h)
-    # Make transition
+    @unpack refreshment, τ = κ
+    τ = reconstruct(τ, integrator=jitter(rng, τ.integrator))
+    z = refresh(rng, refreshment, h, z)
     return transition(rng, τ, h, z)
 end
 
 Adaptation.adapt!(
     h::Hamiltonian,
-    τ::AbstractProposal,
+    κ::AbstractMCMCKernel,
     adaptor::Adaptation.NoAdaptation,
     i::Int,
     n_adapts::Int,
     θ::AbstractVecOrMat{<:AbstractFloat},
     α::AbstractScalarOrVec{<:AbstractFloat}
-) = h, τ, false
+) = h, κ, false
 
 function Adaptation.adapt!(
     h::Hamiltonian,
-    τ::AbstractProposal,
+    κ::AbstractMCMCKernel,
     adaptor::AbstractAdaptor,
     i::Int,
     n_adapts::Int,
@@ -80,10 +82,10 @@ function Adaptation.adapt!(
         adapt!(adaptor, θ, α)
         i == n_adapts && finalize!(adaptor)
         h = reconstruct(h, adaptor)
-        τ = reconstruct(τ, adaptor)
+        κ = reconstruct(κ, adaptor)
         isadapted = true
     end
-    return h, τ, isadapted
+    return h, κ, isadapted
 end
 
 """
@@ -104,7 +106,7 @@ simple_pm_next!(pm, stat::NamedTuple) = ProgressMeter.next!(pm)
 
 sample(
     h::Hamiltonian,
-    τ::AbstractProposal,
+    κ::AbstractMCMCKernel,
     θ::AbstractVecOrMat{<:AbstractFloat},
     n_samples::Int,
     adaptor::AbstractAdaptor=NoAdaptation(),
@@ -116,7 +118,7 @@ sample(
 ) = sample(
     GLOBAL_RNG,
     h,
-    τ,
+    κ,
     θ,
     n_samples,
     adaptor,
@@ -131,7 +133,7 @@ sample(
     sample(
         rng::AbstractRNG,
         h::Hamiltonian,
-        τ::AbstractProposal,
+        κ::AbstractMCMCKernel,
         θ::AbstractVecOrMat{T},
         n_samples::Int,
         adaptor::AbstractAdaptor=NoAdaptation(),
@@ -141,7 +143,7 @@ sample(
         progress::Bool=false
     )
 
-Sample `n_samples` samples using the proposal `τ` under Hamiltonian `h`.
+Sample `n_samples` samples using the proposal `κ` under Hamiltonian `h`.
 - The randomness is controlled by `rng`. 
     - If `rng` is not provided, `GLOBAL_RNG` will be used.
 - The initial point is given by `θ`.
@@ -154,7 +156,7 @@ Sample `n_samples` samples using the proposal `τ` under Hamiltonian `h`.
 function sample(
     rng::Union{AbstractRNG, AbstractVector{<:AbstractRNG}},
     h::Hamiltonian,
-    τ::AbstractProposal,
+    κ::AbstractMCMCKernel,
     θ::T,
     n_samples::Int,
     adaptor::AbstractAdaptor=NoAdaptation(),
@@ -173,11 +175,11 @@ function sample(
     # Progress meter
     pm = progress ? ProgressMeter.Progress(n_samples, desc="Sampling", barlen=31) : nothing
     time = @elapsed for i = 1:n_samples
-        # Make a step
-        t = step(rng, h, τ, t.z)
-        # Adapt h and τ; what mutable is the adaptor
+        # Make a transition
+        t = transition(rng, h, κ, t.z)
+        # Adapt h and κ; what mutable is the adaptor
         tstat = stat(t)
-        h, τ, isadapted = adapt!(h, τ, adaptor, i, n_adapts, t.z.θ, tstat.acceptance_rate)
+        h, κ, isadapted = adapt!(h, κ, adaptor, i, n_adapts, t.z.θ, tstat.acceptance_rate)
         tstat = merge(tstat, (is_adapt=isadapted,))
         # Update progress meter
         if progress
@@ -185,7 +187,7 @@ function sample(
             pm_next!(pm, (iterations=i, tstat..., mass_matrix=h.metric))
         # Report finish of adapation
         elseif verbose && isadapted && i == n_adapts
-            @info "Finished $n_adapts adapation steps" adaptor τ.integrator h.metric
+            @info "Finished $n_adapts adapation steps" adaptor κ.τ.integrator h.metric
         end
         # Store sample
         if !drop_warmup || i > n_adapts
@@ -204,7 +206,7 @@ function sample(
             EBFMI_est = "[" * join(EBFMI_est, ", ") * "]"
             average_acceptance_rate = "[" * join(average_acceptance_rate, ", ") * "]"
         end
-        @info "Finished $n_samples sampling steps for $n_chains chains in $time (s)" h τ EBFMI_est average_acceptance_rate
+        @info "Finished $n_samples sampling steps for $n_chains chains in $time (s)" h κ EBFMI_est average_acceptance_rate
     end
     return θs, stats
 end

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -216,7 +216,7 @@ struct HMCKernel{R, T<:Trajectory} <: AbstractMCMCKernel
     τ::T
 end
 
-HMCKernel(τ::Trajectory) = HMCKernel(FullRefreshment(), τ)
+HMCKernel(τ::Trajectory) = HMCKernel(FullMomentumRefreshment(), τ)
 
 """
 $(SIGNATURES)

--- a/test/adaptation.jl
+++ b/test/adaptation.jl
@@ -103,12 +103,12 @@ let D=10
         θ_init = rand(D)
 
         h = Hamiltonian(metric, ℓπ, ForwardDiff)
-        prop = NUTS(Leapfrog(find_good_stepsize(h, θ_init)))
+        κ = NUTS(Leapfrog(find_good_stepsize(h, θ_init)))
         adaptor = StanHMCAdaptor(
             MassMatrixAdaptor(metric),
-            StepSizeAdaptor(0.8, prop.integrator)
+            StepSizeAdaptor(0.8, κ.τ.integrator)
         )
-        samples, stats = sample(h, prop, θ_init, n_samples, adaptor, n_adapts; verbose=false)
+        samples, stats = sample(h, κ, θ_init, n_samples, adaptor, n_adapts; verbose=false)
         return (samples=samples, stats=stats, adaptor=adaptor)
     end
 

--- a/test/common.jl
+++ b/test/common.jl
@@ -99,10 +99,10 @@ function get_primitives(x, modelgen)
     return ℓπ, ∂ℓπ∂θ, θ₀
 end
 
-function rand_θ_given(x, modelgen, metric, τ; n_samples=20)
+function rand_θ_given(x, modelgen, metric, κ; n_samples=20)
     ℓπ, ∂ℓπ∂θ, θ₀ = get_primitives(x, modelgen)
     h = Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
-    samples, stats = sample(h, τ, θ₀, n_samples; verbose=false, progress=false)
+    samples, stats = sample(h, κ, θ₀, n_samples; verbose=false, progress=false)
     s = samples[end]
     return length(s) == 1 ? s[1] : s
 end

--- a/test/models.jl
+++ b/test/models.jl
@@ -13,10 +13,10 @@ include("common.jl")
     metric = DiagEuclideanMetric(2)
     h = Hamiltonian(metric, ℓπ_gdemo, ForwardDiff)
     init_eps = Leapfrog(0.1)
-    prop = NUTS(init_eps)
-    adaptor = StanHMCAdaptor(MassMatrixAdaptor(metric), StepSizeAdaptor(0.8, prop.integrator))
+    κ = NUTS(init_eps)
+    adaptor = StanHMCAdaptor(MassMatrixAdaptor(metric), StepSizeAdaptor(0.8, κ.τ.integrator))
 
-    samples, _ = sample(rng, h, prop, θ_init, n_samples, adaptor, n_adapts)
+    samples, _ = sample(rng, h, κ, θ_init, n_samples, adaptor, n_adapts)
 
     m_est = mean(map(invlink_gdemo, samples[1000:end]))
 

--- a/test/sampler-vec.jl
+++ b/test/sampler-vec.jl
@@ -36,7 +36,7 @@ include("common.jl")
 
         # NoAdaptation
         Random.seed!(100)
-        samples, stats = sample(h, τ, θ_init_list[i_test], n_samples; verbose=false)
+        samples, stats = sample(h, HMCKernel(τ), θ_init_list[i_test], n_samples; verbose=false)
         @test mean(samples) ≈ zeros(D, n_chains) atol=RNDATOL * n_chains
 
         # Adaptation
@@ -56,7 +56,7 @@ include("common.jl")
             @test show(adaptor) == nothing
 
             Random.seed!(100)
-            samples, stats = sample(h, τ, θ_init_list[i_test], n_samples, adaptor, n_adapts; verbose=false, progress=false)
+            samples, stats = sample(h, HMCKernel(τ), θ_init_list[i_test], n_samples, adaptor, n_adapts; verbose=false, progress=false)
             @test mean(samples) ≈ zeros(D, n_chains) atol=RNDATOL * n_chains
         end
 
@@ -64,7 +64,7 @@ include("common.jl")
         rng = [MersenneTwister(1) for _ in 1:n_chains]
         h = Hamiltonian(metricT((D, n_chains)), ℓπ, ∂ℓπ∂θ)
         θ_init = repeat(rand(D), 1, n_chains)
-        samples, stats = sample(rng, h, τ, θ_init, n_samples; verbose=false)
+        samples, stats = sample(rng, h, HMCKernel(τ), θ_init, n_samples; verbose=false)
         all_same = true
         for i_sample in 2:10
             for j in 2:n_chains
@@ -77,12 +77,12 @@ include("common.jl")
 
     # Simple time benchmark
     let metricT=UnitEuclideanMetric
-        τ = StaticTrajectory(lf, n_steps)
+        κ = StaticTrajectory(lf, n_steps)
 
         time_mat = Vector{Float64}(undef, n_chains_max)
         for (i, n_chains) in enumerate(n_chains_list)
             h = Hamiltonian(metricT((D, n_chains)), ℓπ, ∂ℓπ∂θ)
-            t = @elapsed samples, stats = sample(h, τ, θ_init_list[i], n_samples; verbose=false)
+            t = @elapsed samples, stats = sample(h, κ, θ_init_list[i], n_samples; verbose=false)
             time_mat[i] = t
         end
 
@@ -92,7 +92,7 @@ include("common.jl")
         for (i, n_chains) in enumerate(n_chains_list)
             t = @elapsed for j in 1:n_chains
                 h = Hamiltonian(metricT(D), ℓπ, ∂ℓπ∂θ)
-                samples, stats = sample(h, τ, θ_init_list[i][:,j], n_samples; verbose=false)
+                samples, stats = sample(h, κ, θ_init_list[i][:,j], n_samples; verbose=false)
             end
             time_seperate[i] = t
         end

--- a/test/trajectory.jl
+++ b/test/trajectory.jl
@@ -8,11 +8,11 @@ lf = Leapfrog(ϵ)
 
 θ_init = randn(D)
 h = Hamiltonian(UnitEuclideanMetric(D), ℓπ, ∂ℓπ∂θ)
-τ = NUTS(Leapfrog(find_good_stepsize(h, θ_init)))
+τ = Trajectory{MultinomialTS}(Leapfrog(find_good_stepsize(h, θ_init)), GeneralisedNoUTurn())
 r_init = AdvancedHMC.rand(h.metric)
 
 @testset "Passing random number generator" begin
-    τ_with_jittered_lf = NUTS(JitteredLeapfrog(find_good_stepsize(h, θ_init), 1.0))
+    τ_with_jittered_lf = Trajectory{MultinomialTS}(JitteredLeapfrog(find_good_stepsize(h, θ_init), 1.0), GeneralisedNoUTurn())
     for τ_test in [τ, τ_with_jittered_lf],
         seed in [1234, 5678, 90]
         rng = MersenneTwister(seed)


### PR DESCRIPTION
We are finally here with this interface

```julia
τ = Trajectory(Leapfrog(1e-3), GeneralisedNoUTurn())
κ = HMCKernel(FullRefreshment(), τ)
```

To sum up, this PR introduces a very thin kernel wrapper over refreshment behaviour and the trajectory structs.
Internally, it as simple as
```julia
function transition(rng, h, κ, z)
    @unpack refreshment, τ = κ
    τ = reconstruct(τ, integrator=jitter(rng, τ.integrator))
    z = refresh(rng, refreshment, h, z)
    return transition(rng, τ, h, z)
end
```
As a benefit of such modularity, this is the only place now `jitter` and `refresh` is called.
This is also inline with how we unify Metropolis and multinomial HMC in our paper.

Some notes one things you may ask during review this PR:

1. Why do we need `AbstractMCMCKernel`?
  - This allows a user to specifc other kernels (RWMH, mixture) when needed.
2. Why do we still keep `AbstractTrajectory`?
  - To allow Turing compile so that CI passes
  - This will be removed after we update stuff on the Turing side

Also note that codes are not necessarily in the best location they should be.
I didn't take care of this aspect as I want to minimise code change for review purposes.