### PR TITLE
Fix type-issue in PhasePoint

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -45,8 +45,9 @@ struct PhasePoint{T<:AbstractVecOrMat{<:AbstractFloat}, V<:DualValue}
         @argcheck length(θ) == length(r) == length(ℓπ.gradient) == length(ℓπ.gradient)
         if any(isfinite.((θ, r, ℓπ, ℓκ)) .== false)
             @warn "The current proposal will be rejected due to numerical error(s)." isfinite.((θ, r, ℓπ, ℓκ))
-            ℓπ = DualValue(map(v -> isfinite(v) ? v : -Inf, ℓπ.value), ℓπ.gradient)
-            ℓκ = DualValue(map(v -> isfinite(v) ? v : -Inf, ℓκ.value), ℓκ.gradient)
+            E = eltype(T)
+            ℓπ = DualValue(map(v -> isfinite(v) ? v : -E(Inf), ℓπ.value), ℓπ.gradient)
+            ℓκ = DualValue(map(v -> isfinite(v) ? v : -E(Inf), ℓκ.value), ℓκ.gradient)
         end
         new{T,V}(θ, r, ℓπ, ℓκ)
     end

--- a/test/hamiltonian.jl
+++ b/test/hamiltonian.jl
@@ -6,39 +6,53 @@ using LinearAlgebra: dot, diagm
 include("common.jl")
 
 @testset "PhasePoint" begin
-    init_z1() = PhasePoint([NaN], [NaN], DualValue(0.,[0.]), DualValue(0.,[0.]))
-    init_z2() = PhasePoint([Inf], [Inf], DualValue(0.,[0.]), DualValue(0.,[0.]))
+    for T in [Float32, Float64]
+        init_z1() = PhasePoint(
+            [T(NaN)],
+            [T(NaN)],
+            DualValue(zero(T), [zero(T)]),
+            DualValue(zero(T), [zero(T)])
+        )
+        init_z2() = PhasePoint(
+            [T(Inf)],
+            [T(Inf)],
+            DualValue(zero(T), [zero(T)]),
+            DualValue(zero(T), [zero(T)])
+        )
 
-    @test_logs (:warn, "The current proposal will be rejected due to numerical error(s).") init_z1()
-    @test_logs (:warn, "The current proposal will be rejected due to numerical error(s).") init_z2()
+        @test_logs (:warn, "The current proposal will be rejected due to numerical error(s).") init_z1()
+        @test_logs (:warn, "The current proposal will be rejected due to numerical error(s).") init_z2()
 
-    z1 = init_z1()
-    z2 = init_z2()
+        z1 = init_z1()
+        z2 = init_z2()
 
-    @test z1.ℓπ.value == z2.ℓπ.value
-    @test z1.ℓκ.value == z2.ℓκ.value
+        @test z1.ℓπ.value == z2.ℓπ.value
+        @test z1.ℓκ.value == z2.ℓκ.value
+    end
 end
 
 @testset "Metric" begin
     n_tests = 10
 
-    for _ in 1:n_tests
-        θ_init = randn(D)
-        r_init = randn(D)
+    for T in [Float32, Float64]
+        for _ in 1:n_tests
+            θ_init = randn(T, D)
+            r_init = randn(T, D)
 
-        h = Hamiltonian(UnitEuclideanMetric(D), ℓπ, ∂ℓπ∂θ)
-        @test -AdvancedHMC.neg_energy(h, r_init, θ_init) == sum(abs2, r_init) / 2
-        @test AdvancedHMC.∂H∂r(h, r_init) == r_init
+            h = Hamiltonian(UnitEuclideanMetric(T, D), ℓπ, ∂ℓπ∂θ)
+            @test -AdvancedHMC.neg_energy(h, r_init, θ_init) == sum(abs2, r_init) / 2
+            @test AdvancedHMC.∂H∂r(h, r_init) == r_init
 
-        M⁻¹ = ones(D) + abs.(randn(D))
-        h = Hamiltonian(DiagEuclideanMetric(M⁻¹), ℓπ, ∂ℓπ∂θ)
-        @test -AdvancedHMC.neg_energy(h, r_init, θ_init) ≈ r_init' * diagm(0 => M⁻¹) * r_init / 2
-        @test AdvancedHMC.∂H∂r(h, r_init) == M⁻¹ .* r_init
+            M⁻¹ = ones(T, D) + abs.(randn(T, D))
+            h = Hamiltonian(DiagEuclideanMetric(M⁻¹), ℓπ, ∂ℓπ∂θ)
+            @test -AdvancedHMC.neg_energy(h, r_init, θ_init) ≈ r_init' * diagm(0 => M⁻¹) * r_init / 2
+            @test AdvancedHMC.∂H∂r(h, r_init) == M⁻¹ .* r_init
 
-        m = randn(D, D)
-        M⁻¹ = m' * m
-        h = Hamiltonian(DenseEuclideanMetric(M⁻¹), ℓπ, ∂ℓπ∂θ)
-        @test -AdvancedHMC.neg_energy(h, r_init, θ_init) ≈ r_init' * M⁻¹ * r_init / 2
-        @test AdvancedHMC.∂H∂r(h, r_init) == M⁻¹ * r_init
+            m = randn(T, D, D)
+            M⁻¹ = m' * m
+            h = Hamiltonian(DenseEuclideanMetric(M⁻¹), ℓπ, ∂ℓπ∂θ)
+            @test -AdvancedHMC.neg_energy(h, r_init, θ_init) ≈ r_init' * M⁻¹ * r_init / 2
+            @test AdvancedHMC.∂H∂r(h, r_init) == M⁻¹ * r_init
+        end
     end
 end


### PR DESCRIPTION
`Inf` is hardcoded as `Float64` in `PhasePoint` constructor, which causes issues, e.g.:
```julia
julia> import AdvancedHMC: PhasePoint, DualValue

julia> d1 = DualValue(Float32(Inf), [0f0])
DualValue{Float32, Vector{Float32}}(Inf32, Float32[0.0])

julia> d2 = DualValue(0f0, [0f0])
DualValue{Float32, Vector{Float32}}(0.0f0, Float32[0.0])

julia> PhasePoint([0f0], [0f0], d1, d2)
┌ Warning: The current proposal will be rejected due to numerical error(s).
│   isfinite.((θ, r, ℓπ, ℓκ)) = (true, true, false, true)
└ @ AdvancedHMC ~/Projects/public/AdvancedHMC.jl/src/hamiltonian.jl:47
ERROR: MethodError: Cannot `convert` an object of type 
  DualValue{Float64,Array{Float32{},1}} to an object of type 
  DualValue{Float32,Array{Float32{},1}}
Closest candidates are:
  convert(::Type{T}, ::T) where T at essentials.jl:205
Stacktrace:
 [1] PhasePoint(θ::Vector{Float32}, r::Vector{Float32}, ℓπ::DualValue{Float32, Vector{Float32}}, ℓκ::DualValue{Float32, Vector{Float32}})
   @ AdvancedHMC ~/Projects/public/AdvancedHMC.jl/src/hamiltonian.jl:51
 [2] top-level scope
   @ REPL[102]:1
```

Also, is there a reason why we're doing this `map` to check if something is finite and replace it with `inf` if it's not @xukai92 ? I mean, if `isfinite` returns `false` then the value should already be `inf`, no?