### PR TITLE
PhasePoint constructor bug when using GPU

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -45,6 +45,7 @@ struct PhasePoint{T<:AbstractVecOrMat{<:AbstractFloat}, V<:DualValue}
         @argcheck length(θ) == length(r) == length(ℓπ.gradient) == length(ℓπ.gradient)
         if any(isfinite.((θ, r, ℓπ, ℓκ)) .== false)
             @warn "The current proposal will be rejected due to numerical error(s)." isfinite.((θ, r, ℓπ, ℓκ))
+            # NOTE eltype has to be inlined to avoid type stability issue; see #267
             ℓπ = DualValue(
                 map(v -> isfinite(v) ? v : -eltype(T)(Inf), ℓπ.value), 
                 ℓπ.gradient

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -45,9 +45,14 @@ struct PhasePoint{T<:AbstractVecOrMat{<:AbstractFloat}, V<:DualValue}
         @argcheck length(θ) == length(r) == length(ℓπ.gradient) == length(ℓπ.gradient)
         if any(isfinite.((θ, r, ℓπ, ℓκ)) .== false)
             @warn "The current proposal will be rejected due to numerical error(s)." isfinite.((θ, r, ℓπ, ℓκ))
-            E = eltype(T)
-            ℓπ = DualValue(map(v -> isfinite(v) ? v : -E(Inf), ℓπ.value), ℓπ.gradient)
-            ℓκ = DualValue(map(v -> isfinite(v) ? v : -E(Inf), ℓκ.value), ℓκ.gradient)
+            ℓπ = DualValue(
+                map(v -> isfinite(v) ? v : -eltype(T)(Inf), ℓπ.value), 
+                ℓπ.gradient
+            )
+            ℓκ = DualValue(
+                map(v -> isfinite(v) ? v : -eltype(T)(Inf), ℓκ.value), 
+                ℓκ.gradient
+            )
         end
         new{T,V}(θ, r, ℓπ, ℓκ)
     end

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -1,5 +1,6 @@
 using Test
 using AdvancedHMC
+using AdvancedHMC: DualValue, PhasePoint
 using CUDA
 
 @testset "AdvancedHMC GPU" begin
@@ -21,4 +22,30 @@ using CUDA
     proposal = HMCKernel(Trajectory{EndPointTS}(integrator, FixedNSteps(5)))
 
     samples, stats = sample(hamiltonian, proposal, θ₀, n_samples)
+end
+
+@testset "PhasePoint GPU" begin
+    for T in [Float32, Float64]
+        init_z1() = PhasePoint(
+            CuArray([T(NaN) T(NaN)]),
+            CuArray([T(NaN) T(NaN)]),
+            DualValue(CuArray(zeros(T, 2)), CuArray(zeros(T, 1, 2))),
+            DualValue(CuArray(zeros(T, 2)), CuArray(zeros(T, 1, 2)))
+        )
+        init_z2() = PhasePoint(
+            CuArray([T(Inf) T(Inf)]),
+            CuArray([T(Inf) T(Inf)]),
+            DualValue(CuArray(zeros(T, 2)), CuArray(zeros(T, 1, 2))),
+            DualValue(CuArray(zeros(T, 2)), CuArray(zeros(T, 1, 2)))
+        )
+
+        @test_logs (:warn, "The current proposal will be rejected due to numerical error(s).") init_z1()
+        @test_logs (:warn, "The current proposal will be rejected due to numerical error(s).") init_z2()
+
+        z1 = init_z1()
+        z2 = init_z2()
+
+        @test z1.ℓπ.value == z2.ℓπ.value
+        @test z1.ℓκ.value == z2.ℓκ.value
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Distributed, Test, CUDA
 
-println("Envronment variables for testing")
+println("Environment variables for testing")
 println(ENV)
 
 @testset "AdvancedHMC" begin


### PR DESCRIPTION
There seems to be a type-inference issue when using the PhasePoint constructor with CUDA.

MWE:
```julia
using CUDA
using AdvancedHMC: PhasePoint, DualValue

PhasePoint(
    CuArray([T(NaN) T(NaN)]),
    CuArray([T(NaN) T(NaN)]),
    DualValue(CuArray(zeros(T, 2)), CuArray(zeros(T, 1, 2))),
    DualValue(CuArray(zeros(T, 2)), CuArray(zeros(T, 1, 2)))
)
```
results in 
```
┌ Warning: The current proposal will be rejected due to numerical error(s).
│   isfinite.((θ, r, ℓπ, ℓκ)) = (false, false, true, true)
└ @ AdvancedHMC ~/dev/AdvancedHMC.jl/src/hamiltonian.jl:47
ERROR: LoadError: GPU broadcast resulted in non-concrete element type Any.
This probably means that the function you are broadcasting contains an error or type instability.
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] copy
   @ ~/.julia/packages/GPUArrays/Z5nPF/src/host/broadcast.jl:44 [inlined]
 [3] materialize(bc::Base.Broadcast.Broadcasted{CUDA.CuArrayStyle{1}, Nothing, AdvancedHMC.var"#71#73"{DataType}, Tuple{CuArray{Float32, 1}}})
   @ Base.Broadcast ./broadcast.jl:883
 [4] map(::Function, ::CuArray{Float32, 1})
   @ GPUArrays ~/.julia/packages/GPUArrays/Z5nPF/src/host/broadcast.jl:86
 [5] PhasePoint(θ::CuArray{Float32, 2}, r::CuArray{Float32, 2}, ℓπ::DualValue{CuArray{Float32, 1}, CuArray{Float32, 2}}, ℓκ::DualValue{CuArray{Float32, 1}, CuArray{Float32, 2}})
   @ AdvancedHMC ~/dev/AdvancedHMC.jl/src/hamiltonian.jl:49
 [6] top-level scope
   @ ~/dev/hmc_benchmark/ahmc/phasepoint_mwe.jl:4
 [7] include(fname::String)
   @ Base.MainInclude ./client.jl:444
 [8] top-level scope
   @ REPL[14]:1
 [9] top-level scope
   @ ~/.julia/packages/CUDA/3VnCC/src/initialization.jl:81
in expression starting at /home/reichelt/dev/hmc_benchmark/ahmc/phasepoint_mwe.jl:4
```

The fix is simple and I copied the PhasePoint tests to `test/cuda.jl` and adjusted them for the GPU.