### PR TITLE
Improve Hamiltonian constructors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-AbstractMCMC = "4.2.1"
+AbstractMCMC = "4.2"
 ArgCheck = "1, 2"
 DocStringExtensions = "0.8, 0.9"
 InplaceOps = "0.3"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedHMC"
 uuid = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
-version = "0.4"
+version = "0.4.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
@@ -20,7 +20,7 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-AbstractMCMC = "4.2"
+AbstractMCMC = "4.2.1"
 ArgCheck = "1, 2"
 DocStringExtensions = "0.8, 0.9"
 InplaceOps = "0.3"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ struct LogTargetDensity
 end
 LogDensityProblems.logdensity(p::LogTargetDensity, θ) = -sum(abs2, θ) / 2  # standard multivariate normal
 LogDensityProblems.dimension(p::LogTargetDensity) = p.dim
+LogDensityProblems.capabilities(::Type{LogTargetDensity}) = LogDensityProblems.LogDensityOrder{0}()
 
 # Choose parameter dimensionality and initial parameter value
 D = 10; initial_θ = rand(D)

--- a/test/common.jl
+++ b/test/common.jl
@@ -18,6 +18,7 @@ using Bijectors: Bijectors
 struct LogDensityDistribution{D<:Distributions.Distribution}
     dist::D
 end
+
 LogDensityProblems.dimension(d::LogDensityDistribution) = length(d.dist)
 function LogDensityProblems.logdensity(ld::LogDensityDistribution, y)
     d = ld.dist
@@ -25,6 +26,7 @@ function LogDensityProblems.logdensity(ld::LogDensityDistribution, y)
     x, logjac = Bijectors.with_logabsdet_jacobian(b, y)
     return logpdf(d, x) + logjac
 end
+LogDensityProblems.capabilities(::Type{<:LogDensityDistribution}) = LogDensityProblems.LogDensityOrder{0}()
 
 # Hand-coded multivariate Gaussian
 
@@ -41,6 +43,7 @@ end
 
 LogDensityProblems.dimension(g::Gaussian) = dim(g.m)
 LogDensityProblems.logdensity(g::Gaussian, x) = ℓπ_gaussian(g.m. g.s, x)
+LogDensityProblems.capabilities(::Type{<:Gaussian}) = LogDensityProblems.LogDensityOrder{0}()
 
 function ∇ℓπ_gaussianl(m, s, x)
     g = m .- x
@@ -97,6 +100,7 @@ end
 # Make compat with `LogDensityProblems`.
 LogDensityProblems.dimension(::typeof(ℓπ_gdemo)) = 2
 LogDensityProblems.logdensity(::typeof(ℓπ_gdemo), θ) = ℓπ_gdemo(θ)
+LogDensityProblems.capabilities(::Type{typeof(ℓπ_gdemo)}) = LogDensityProblems.LogDensityOrder{0}()
 
 test_show(x) = test_show(s -> length(s) > 0, x)
 function test_show(pred, x)

--- a/test/demo.jl
+++ b/test/demo.jl
@@ -7,8 +7,10 @@ using LinearAlgebra
     struct DemoProblem
         dim::Int
     end
+
     LogDensityProblems.logdensity(p::DemoProblem, θ) = logpdf(MvNormal(zeros(p.dim), I), θ)
     LogDensityProblems.dimension(p::DemoProblem) = p.dim
+    LogDensityProblems.capabilities(::Type{DemoProblem}) = LogDensityProblems.LogDensityOrder{0}()
 
     # Choose parameter dimensionality and initial parameter value
     D = 10
@@ -50,10 +52,13 @@ end
     # target distribution parametrized by ComponentsArray
     p1 = ComponentVector(μ=2.0, σ=1)
     struct DemoProblemComponentArrays end
+
     function LogDensityProblems.logdensity(::DemoProblemComponentArrays, p::ComponentArray)
         return -((1 - p.μ) / p.σ)^2
     end
     LogDensityProblems.dimension(::DemoProblemComponentArrays) = 2
+    LogDensityProblems.capabilities(::Type{DemoProblemComponentArrays}) = LogDensityProblems.LogDensityOrder{0}()
+
     ℓπ = DemoProblemComponentArrays()
 
     # Define a Hamiltonian system

--- a/test/integrator.jl
+++ b/test/integrator.jl
@@ -110,8 +110,11 @@ using Statistics: mean
         struct NegU
             dim::Int
         end
-        LogDensityProblems.logdensity(d::NegU, x) = -dot(x, x) / 2
+
+        LogDensityProblems.logdensity(::NegU, x) = -dot(x, x) / 2
         LogDensityProblems.dimension(d::NegU) = d.dim
+        LogDensityProblems.capabilities(::Type{NegU}) = LogDensityProblems.LogDensityOrder{0}()
+
         negU = NegU(1)
 
         ϵ = 0.01


### PR DESCRIPTION
This PR proposes some changes of the `Hamiltonian` constructors:
- For log density functions that already support computation of the gradient as well (via `logdensity_and_gradient`) an AD backend is not used automatically but only if explicitly specified
- `LogDensityModel`s are handled in the same way as if only their log density would have been provided, ie, in particular ForwardDiff is used automatically if the log density does not support computation of the gradient