### PR TITLE
kwarg nadapt

### DIFF
--- a/src/abstractmcmc.jl
+++ b/src/abstractmcmc.jl
@@ -37,6 +37,7 @@ function AbstractMCMC.sample(
     model::LogDensityModel,
     sampler::AbstractHMCSampler,
     N::Integer;
+    n_adapts::Int = min(div(N, 10), 1_000),
     progress = true,
     verbose = false,
     callback = nothing,
@@ -66,6 +67,7 @@ function AbstractMCMC.sample(
     parallel::AbstractMCMC.AbstractMCMCEnsemble,
     N::Integer,
     nchains::Integer;
+    n_adapts::Int = min(div(N, 10), 1_000),
     progress = true,
     verbose = false,
     callback = nothing,
@@ -150,7 +152,7 @@ function AbstractMCMC.step(
 
     # Adapt h and spl.
     tstat = stat(t)
-    n_adapts = get_nadapts(spl)
+    n_adapts = kwargs[:n_adapts]
     h, κ, isadapted = adapt!(h, κ, adaptor, i, n_adapts, t.z.θ, tstat.acceptance_rate)
     tstat = merge(tstat, (is_adapt = isadapted,))
 
@@ -333,11 +335,6 @@ function make_adaptor(
 )
     return spl.adaptor
 end
-
-#########
-
-get_nadapts(spl::Union{HMCSampler,NUTS,HMCDA}) = spl.n_adapts
-get_nadapts(spl::HMC) = 0
 
 #########
 

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -56,8 +56,6 @@ NUTS(n_adapts=1000, δ=0.65)  # Use 1000 adaption steps, and target accept ratio
 ```
 """
 struct NUTS{T<:Real} <: AbstractHMCSampler{T}
-    "Number of adaptation steps."
-    n_adapts::Int
     "Target acceptance rate for dual averaging."
     δ::T
     "Maximum doubling tree depth."
@@ -73,7 +71,6 @@ struct NUTS{T<:Real} <: AbstractHMCSampler{T}
 end
 
 function NUTS(
-    n_adapts,
     δ;
     max_depth = 10,
     Δ_max = 1000.0,
@@ -82,7 +79,7 @@ function NUTS(
     metric = :diagonal,
 )
     T = typeof(δ)
-    return NUTS(n_adapts, δ, max_depth, T(Δ_max), T(init_ϵ), integrator, metric)
+    return NUTS(δ, max_depth, T(Δ_max), T(init_ϵ), integrator, metric)
 end
 
 ###########
@@ -143,8 +140,6 @@ For more information, please view the following paper ([arXiv link](https://arxi
   Research 15, no. 1 (2014): 1593-1623.
 """
 struct HMCDA{T<:Real} <: AbstractHMCSampler{T}
-    "`Number of adaptation steps."
-    n_adapts::Int
     "Target acceptance rate for dual averaging."
     δ::T
     "Target leapfrog length."
@@ -157,10 +152,10 @@ struct HMCDA{T<:Real} <: AbstractHMCSampler{T}
     metric::Union{Symbol,AbstractMetric}
 end
 
-function HMCDA(n_adapts, δ, λ; init_ϵ = 0.0, integrator = :leapfrog, metric = :diagonal)
+function HMCDA(δ, λ; init_ϵ = 0.0, integrator = :leapfrog, metric = :diagonal)
     if typeof(δ) != typeof(λ)
         @warn "typeof(δ) != typeof(λ) --> using typeof(δ)"
     end
     T = typeof(δ)
-    return HMCDA(n_adapts, δ, T(λ), T(init_ϵ), integrator, metric)
+    return HMCDA(δ, T(λ), T(init_ϵ), integrator, metric)
 end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -2,11 +2,11 @@ using AdvancedHMC, AbstractMCMC, Random
 include("common.jl")
 
 # Initalize samplers
-nuts = NUTS(1000, 0.8)
-nuts_32 = NUTS(1000, 0.8f0)
+nuts = NUTS(0.8)
+nuts_32 = NUTS(0.8f0)
 hmc = HMC(0.1, 25)
-hmcda = HMCDA(1000, 0.8, 1.0)
-hmcda_32 = HMCDA(1000, 0.8f0, 1.0)
+hmcda = HMCDA(0.8, 1.0)
+hmcda_32 = HMCDA(0.8f0, 1.0)
 
 integrator = Leapfrog(1e-3)
 kernel = HMCKernel(Trajectory{MultinomialTS}(integrator, GeneralisedNoUTurn()))
@@ -25,7 +25,6 @@ custom = HMCSampler(kernel, metric, adaptor)
     @test typeof(nuts) <: AbstractMCMC.AbstractSampler
 
     # NUTS
-    @test nuts.n_adapts == 1000
     @test nuts.δ == 0.8
     @test nuts.max_depth == 10
     @test nuts.Δ_max == 1000.0
@@ -34,7 +33,6 @@ custom = HMCSampler(kernel, metric, adaptor)
     @test nuts.metric == :diagonal
 
     # NUTS Float32
-    @test nuts_32.n_adapts == 1000
     @test nuts_32.δ == 0.8f0
     @test nuts_32.max_depth == 10
     @test nuts_32.Δ_max == 1000.0f0
@@ -47,7 +45,6 @@ custom = HMCSampler(kernel, metric, adaptor)
     @test hmc.metric == :diagonal
 
     # HMCDA
-    @test hmcda.n_adapts == 1000
     @test hmcda.δ == 0.8
     @test hmcda.λ == 1.0
     @test hmcda.init_ϵ == 0.0
@@ -55,7 +52,6 @@ custom = HMCSampler(kernel, metric, adaptor)
     @test hmcda.metric == :diagonal
 
     # HMCDA Float32
-    @test hmcda_32.n_adapts == 1000
     @test hmcda_32.δ == 0.8f0
     @test hmcda_32.λ == 1.0f0
     @test hmcda_32.init_ϵ == 0.0f0
@@ -65,11 +61,11 @@ end
     rng = MersenneTwister(0)
     θ_init = randn(rng, 2)
     logdensitymodel = AbstractMCMC.LogDensityModel(ℓπ_gdemo)
-    _, nuts_state = AbstractMCMC.step(rng, logdensitymodel, nuts; init_params = θ_init)
-    _, hmc_state = AbstractMCMC.step(rng, logdensitymodel, hmc; init_params = θ_init)
+    _, nuts_state = AbstractMCMC.step(rng, logdensitymodel, nuts; n_adapts = 0, init_params = θ_init)
+    _, hmc_state = AbstractMCMC.step(rng, logdensitymodel, hmc; n_adapts = 0, init_params = θ_init)
     _, nuts_32_state =
-        AbstractMCMC.step(rng, logdensitymodel, nuts_32; init_params = θ_init)
-    _, custom_state = AbstractMCMC.step(rng, logdensitymodel, custom; init_params = θ_init)
+        AbstractMCMC.step(rng, logdensitymodel, nuts_32; n_adapts = 0, init_params = θ_init)
+    _, custom_state = AbstractMCMC.step(rng, logdensitymodel, custom; n_adapts = 0, init_params = θ_init)
 
     # Metric
     @test typeof(nuts_state.metric) == DiagEuclideanMetric{Float64,Vector{Float64}}


### PR DESCRIPTION
The current constructors take n_adapts as well as other initialization options as a field to follow the Turing API as close as possible.
However, ideally the intialization should be independent of the sampler. 
This PR is a small step towards that goal. 
In the future we would like to give other initialization options the same treatment. 
