### PR TITLE
NUTS kernel options

### DIFF
--- a/src/abstractmcmc.jl
+++ b/src/abstractmcmc.jl
@@ -354,7 +354,7 @@ end
 #########
 
 function make_kernel(spl::NUTS, integrator::AbstractIntegrator)
-    return HMCKernel(Trajectory{MultinomialTS}(integrator, GeneralisedNoUTurn()))
+    return HMCKernel(Trajectory{MultinomialTS}(integrator, GeneralisedNoUTurn(spl.max_depth, spl.Δ_max)))
 end
 
 function make_kernel(spl::HMC, integrator::AbstractIntegrator)


### PR DESCRIPTION
Is there a reason why we are not passing the sampler options to the `make_kernel` function?