### PR TITLE
fix: arg order

### DIFF
--- a/research/src/riemannian_hmc.jl
+++ b/research/src/riemannian_hmc.jl
@@ -242,7 +242,7 @@ phasepoint(
     θ::T,
     r::T;
     ℓπ = ∂H∂θ(h, θ),
-    ℓκ = DualValue(neg_energy(h, r, θ), ∂H∂r(h, r, θ)),
+    ℓκ = DualValue(neg_energy(h, r, θ), ∂H∂r(h, θ, r)),
 ) where {T<:AbstractVecOrMat} = PhasePoint(θ, r, ℓπ, ℓκ)
 
 # Negative kinetic energy


### PR DESCRIPTION
port a small fix on current research code in case someone is using the RHMC implementation

on this regard we should probably somehow unify the order of position and momentum variables in all functions...