### PR TITLE
Use `Base.RefValue`

### DIFF
--- a/src/abstractmcmc.jl
+++ b/src/abstractmcmc.jl
@@ -189,8 +189,8 @@ struct HMCProgressCallback{P}
     "If `progress` is not specified and this is `true` some information will be logged upon completion of adaptation."
     verbose::Bool
     "Number of divergent transitions fo far."
-    num_divergent_transitions::Ref{Int}
-    num_divergent_transitions_during_adaption::Ref{Int}
+    num_divergent_transitions::Base.RefValue{Int}
+    num_divergent_transitions_during_adaption::Base.RefValue{Int}
 end
 
 function HMCProgressCallback(n_samples; progress = true, verbose = false)


### PR DESCRIPTION
`Ref{Int}` is an abstract type:

```julia
julia> typeof(Ref(0))
Base.RefValue{Int64}

julia> typeof(Ref(0)) <: Ref{Int}
true

julia> isabstracttype(Ref{Int})
true

julia> isabstracttype(Base.RefValue{Int})
false
```