### PR TITLE
Implement supports for sampling momentum with quasi-random sequences.

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -207,3 +207,21 @@ refresh(
     z.θ,
     ref.α * z.r + sqrt(1 - ref.α^2) * rand(rng, h.metric, h.kinetic, z.θ),
 )
+
+
+
+include("quasi_MC.jl")
+
+"Quasi-random momentum refreshment."
+struct QuasiRandomMomentumRefreshment <: AbstractMomentumRefreshment 
+    quasi_seed::Quasi_MC_seed
+end
+
+function refresh(
+    rng::Union{AbstractRNG,AbstractVector{<:AbstractRNG}},
+    ref::QuasiRandomMomentumRefreshment,
+    h::Hamiltonian,
+    z::PhasePoint,
+) 
+    return phasepoint(h, z.θ, rand(rng, h.metric, h.kinetic, z.θ, ref.quasi_seed))
+end

--- a/src/quasi_MC.jl
+++ b/src/quasi_MC.jl
@@ -1,0 +1,26 @@
+using QuasiMonteCarlo, Distributions
+
+mutable struct Quasi_MC_seed
+    array::AbstractVecOrMat{<:Real}
+    counter::Int
+
+    # Custom constructor with a default value for `counter`
+    function Quasi_MC_seed(array::AbstractVecOrMat{<:Real}, counter::Int = 1)
+        new(array, counter)
+    end
+end
+
+function get_next_vector(q::Quasi_MC_seed; normalized = true)
+    val = q.array[:, q.counter]
+    q.counter += 1
+    if normalized
+        return uniform_to_normal(val)
+    else
+        return val
+    end
+end
+
+function uniform_to_normal(uniform_vector::Vector{Float64})::Vector{Float64}
+    normal_dist = Normal(0, 1)
+    return [quantile(normal_dist, u) for u in uniform_vector]
+end


### PR DESCRIPTION
An additional momentum refreshment struct "QuasiRandomMomentumRefreshment"<:AbstractRefreshment is added, along with its refresh() function and other necessary changes. 

Passing this struct to the HMCKernel() will change how momentum is sampled at each iteration. Instead of drawing momentum i.i.d. from the target Gaussian distribution, the momentum will be drawn from a low-discrepancy (quasi-random) sequence whose limiting distribution is the target multi-dimensional Gaussian.

https://en.wikipedia.org/wiki/Low-discrepancy_sequence