### PR TITLE
Add `isnan(::PhasePoint)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedHMC"
 uuid = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -108,6 +108,10 @@ Base.isfinite(v::DualValue) = all(isfinite, v.value) && all(isfinite, v.gradient
 Base.isfinite(v::AbstractVecOrMat) = all(isfinite, v)
 Base.isfinite(z::PhasePoint) = isfinite(z.ℓπ) && isfinite(z.ℓκ)
 
+Base.isnan(v::DualValue) = any(isnan, v.value) || any(isnan, v.gradient)
+Base.isnan(v::AbstractVecOrMat) = any(isnan, v)
+Base.isnan(z::PhasePoint) = isnan(z.ℓπ) || isnan(z.ℓκ)
+
 ###
 ### Negative energy (or log probability) functions.
 ### NOTE: the general form (i.e. non-Euclidean) of K depends on both θ and r.


### PR DESCRIPTION
See https://github.com/TuringLang/Turing.jl/issues/2389 for full context, but TLDR: if any of the values inside the PhasePoint are NaN's, we want Turing's sampling to error immediately instead of the current behaviour which is to enter an infinite loop.

This function provides a way for upstream packages such as Turing to detect this error condition.