### PR TITLE
Deepcopy adaptor before starting sampling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedHMC"
 uuid = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedHMC"
 uuid = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
-version = "0.6.4"
+version = "0.6.5"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/AdvancedHMC.jl
+++ b/src/AdvancedHMC.jl
@@ -6,8 +6,7 @@ using Statistics: mean, var, middle
 using LinearAlgebra:
     Symmetric, UpperTriangular, mul!, ldiv!, dot, I, diag, cholesky, UniformScaling
 using StatsFuns: logaddexp, logsumexp
-import Random
-using Random: GLOBAL_RNG, AbstractRNG
+import Random: Random, AbstractRNG
 using ProgressMeter: ProgressMeter
 using SimpleUnPack: @unpack
 

--- a/src/abstractmcmc.jl
+++ b/src/abstractmcmc.jl
@@ -55,7 +55,7 @@ A convenient wrapper around `AbstractMCMC.sample` avoiding explicit construction
 """
 
 function AbstractMCMC.sample(
-    rng::Random.AbstractRNG,
+    rng::AbstractRNG,
     model::AbstractMCMC.LogDensityModel,
     sampler::AbstractHMCSampler,
     N::Integer;
@@ -92,7 +92,7 @@ function AbstractMCMC.sample(
 end
 
 function AbstractMCMC.sample(
-    rng::Random.AbstractRNG,
+    rng::AbstractRNG,
     model::AbstractMCMC.LogDensityModel,
     sampler::AbstractHMCSampler,
     parallel::AbstractMCMC.AbstractMCMCEnsemble,
@@ -318,7 +318,7 @@ end
 #########
 
 function make_step_size(
-    rng::Random.AbstractRNG,
+    rng::AbstractRNG,
     spl::HMCSampler,
     hamiltonian::Hamiltonian,
     initial_params,
@@ -329,7 +329,7 @@ function make_step_size(
 end
 
 function make_step_size(
-    rng::Random.AbstractRNG,
+    rng::AbstractRNG,
     spl::AbstractHMCSampler,
     hamiltonian::Hamiltonian,
     initial_params,
@@ -340,7 +340,7 @@ function make_step_size(
 end
 
 function make_step_size(
-    rng::Random.AbstractRNG,
+    rng::AbstractRNG,
     integrator::AbstractIntegrator,
     T::Type,
     hamiltonian::Hamiltonian,
@@ -356,7 +356,7 @@ function make_step_size(
 end
 
 function make_step_size(
-    rng::Random.AbstractRNG,
+    rng::AbstractRNG,
     integrator::Symbol,
     T::Type,
     hamiltonian::Hamiltonian,

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -108,6 +108,10 @@ Base.isfinite(v::DualValue) = all(isfinite, v.value) && all(isfinite, v.gradient
 Base.isfinite(v::AbstractVecOrMat) = all(isfinite, v)
 Base.isfinite(z::PhasePoint) = isfinite(z.ℓπ) && isfinite(z.ℓκ)
 
+Base.isnan(v::DualValue) = any(isnan, v.value) || any(isnan, v.gradient)
+Base.isnan(v::AbstractVecOrMat) = any(isnan, v)
+Base.isnan(z::PhasePoint) = isnan(z.ℓπ) || isnan(z.ℓκ)
+
 ###
 ### Negative energy (or log probability) functions.
 ### NOTE: the general form (i.e. non-Euclidean) of K depends on both θ and r.

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -138,7 +138,7 @@ Base.rand(
     kinetic::AbstractKinetic,
 ) = _rand(rng, metric, kinetic)
 Base.rand(metric::AbstractMetric, kinetic::AbstractKinetic) =
-    rand(GLOBAL_RNG, metric, kinetic)
+    rand(Random.default_rng(), metric, kinetic)
 
 # ignore θ by default unless defined by the specific kinetic (i.e. not position-dependent)
 Base.rand(
@@ -154,4 +154,4 @@ Base.rand(
     θ::AbstractVecOrMat,
 ) = rand(rng, metric, kinetic)
 Base.rand(metric::AbstractMetric, kinetic::AbstractKinetic, θ::AbstractVecOrMat) =
-    rand(metric, kinetic)
+    rand(Random.default_rng(), metric, kinetic)

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -118,7 +118,7 @@ sample(
     progress::Bool = false,
     (pm_next!)::Function = pm_next!,
 ) = sample(
-    GLOBAL_RNG,
+    Random.default_rng(),
     h,
     κ,
     θ,
@@ -146,7 +146,7 @@ sample(
     )
 Sample `n_samples` samples using the proposal `κ` under Hamiltonian `h`.
 - The randomness is controlled by `rng`. 
-    - If `rng` is not provided, `GLOBAL_RNG` will be used.
+    - If `rng` is not provided, `Random.default_rng()` will be used.
 - The initial point is given by `θ`.
 - The adaptor is set by `adaptor`, for which the default is no adaptation.
     - It will perform `n_adapts` steps of adaptation, for which the default is the minimum of `1_000` and 10% of `n_samples`
@@ -181,6 +181,7 @@ function sample(
         nothing
     time = @elapsed for i = 1:n_samples
         # Make a transition
+        # i == 2 && error(κ.τ.integrator)
         t = transition(rng, h, κ, t.z)
         # Adapt h and κ; what mutable is the adaptor
         tstat = stat(t)

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -3,7 +3,7 @@
 ####
 #### Developers' Notes
 ####
-#### Not all functions that use `rng` require a fallback function with `GLOBAL_RNG`
+#### Not all functions that use `rng` require a fallback function with `Random.default_rng()`
 #### as default. In short, only those exported to other libries need such a fallback
 #### function. Internal uses shall always use the explict `rng` version. (Kai Xu 6/Jul/19)
 
@@ -241,10 +241,10 @@ $(SIGNATURES)
 
 Make a MCMC transition from phase point `z` using the trajectory `τ` under Hamiltonian `h`.
 
-NOTE: This is a RNG-implicit fallback function for `transition(GLOBAL_RNG, τ, h, z)`
+NOTE: This is a RNG-implicit fallback function for `transition(Random.default_rng(), τ, h, z)`
 """
 function transition(τ::Trajectory, h::Hamiltonian, z::PhasePoint)
-    return transition(GLOBAL_RNG, τ, h, z)
+    return transition(Random.default_rng(), τ, h, z)
 end
 
 ###
@@ -834,7 +834,7 @@ function find_good_stepsize(
     θ::AbstractVector{<:AbstractFloat};
     max_n_iters::Int = 100,
 )
-    return find_good_stepsize(GLOBAL_RNG, h, θ; max_n_iters = max_n_iters)
+    return find_good_stepsize(Random.default_rng(), h, θ; max_n_iters = max_n_iters)
 end
 
 "Perform MH acceptance based on energy, i.e. negative log probability."

--- a/test/adaptation.jl
+++ b/test/adaptation.jl
@@ -14,7 +14,17 @@ function runnuts(ℓπ, metric; n_samples = 3_000)
     integrator = AdvancedHMC.make_integrator(nuts, step_size)
     κ = AdvancedHMC.make_kernel(nuts, integrator)
     adaptor = AdvancedHMC.make_adaptor(nuts, metric, integrator)
-    samples, stats = sample(h, κ, θ_init, n_samples, adaptor, n_adapts; verbose = false)
+    # Use mutating version of sample() here
+    samples, stats = AdvancedHMC.sample_mutating_adaptor(
+        rng,
+        h,
+        κ,
+        θ_init,
+        n_samples,
+        adaptor,
+        n_adapts;
+        verbose = false,
+    )
     return (samples = samples, stats = stats, adaptor = adaptor)
 end
 


### PR DESCRIPTION
The implementation of `sample()` in AdvancedHMC mutates the adaptor passed in, which is both unintuitive (it's `sample` not `sample!`) and also undocumented (see #379).

This PR:

- renames `sample()` to `sample_mutating_adaptor()` (other suggestions for names welcome – I didn't want to use `sample!` as that has another meaning)
- makes a new version of `sample()` which performs a deepcopy of the adaptor before handing over to `sample_mutating_adaptor()`
- adds tests
- also updates `Random.GLOBAL_RNG` to `Random.default_rng()`, which I think is the proper modern method of accessing the global PRNG state.

Draft for now to check that CI passes + also to wait for #381 to be merged. (or rejected 😱 )