### PR TITLE
Specialize on `Type`s and use if-else instead of `Val`-dispatches

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedHMC"
 uuid = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/AdvancedHMC.jl
+++ b/src/AdvancedHMC.jl
@@ -95,11 +95,8 @@ MassMatrixAdaptor(m::DenseEuclideanMetric{T}) where {T} =
 MassMatrixAdaptor(::Type{TM}, sz::Dims = (2,)) where {TM<:AbstractMetric} =
     MassMatrixAdaptor(Float64, TM, sz)
 
-MassMatrixAdaptor(
-    ::Type{T},
-    ::Type{TM},
-    sz::Dims = (2,),
-) where {T,TM<:AbstractMetric} = MassMatrixAdaptor(TM(T, sz))
+MassMatrixAdaptor(::Type{T}, ::Type{TM}, sz::Dims = (2,)) where {T,TM<:AbstractMetric} =
+    MassMatrixAdaptor(TM(T, sz))
 
 # Deprecations
 

--- a/src/AdvancedHMC.jl
+++ b/src/AdvancedHMC.jl
@@ -92,13 +92,13 @@ MassMatrixAdaptor(m::DiagEuclideanMetric{T}) where {T} =
 MassMatrixAdaptor(m::DenseEuclideanMetric{T}) where {T} =
     WelfordCov{T}(size(m); cov = copy(m.M⁻¹))
 
-MassMatrixAdaptor(m::Type{TM}, sz::Tuple{Vararg{Int}} = (2,)) where {TM<:AbstractMetric} =
-    MassMatrixAdaptor(Float64, m, sz)
+MassMatrixAdaptor(::Type{TM}, sz::Dims = (2,)) where {TM<:AbstractMetric} =
+    MassMatrixAdaptor(Float64, TM, sz)
 
 MassMatrixAdaptor(
     ::Type{T},
     ::Type{TM},
-    sz::Tuple{Vararg{Int}} = (2,),
+    sz::Dims = (2,),
 ) where {T,TM<:AbstractMetric} = MassMatrixAdaptor(TM(T, sz))
 
 # Deprecations

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -92,12 +92,6 @@ Base.size(e::DenseEuclideanMetric, dim...) = size(e._temp, dim...)
 Base.show(io::IO, dem::DenseEuclideanMetric) =
     print(io, "DenseEuclideanMetric(diag=$(_string_M⁻¹(dem.M⁻¹)))")
 
-# getname functions
-for T in (UnitEuclideanMetric, DiagEuclideanMetric, DenseEuclideanMetric)
-    @eval getname(::Type{<:$T}) = $T
-end
-getname(m::T) where {T<:AbstractMetric} = getname(T)
-
 # `rand` functions for `metric` types.
 
 function _rand(


### PR DESCRIPTION
The PR tries to improve a few things I noticed when skimming through the code, most noteably

- missing specializations on `Type`s: Julia does not specialize on `T::Type`, one has to use `::Type{T}`

- misuse of `Val` in type-unstable code involving `Symbol`s: this does not recover type stability but leads to dynamic dispatches which are quite slow. Compare, e.g.,

```julia
julia> using Chairmarks

julia> f(x::Symbol) = f(Val(x))

julia> f(::Val{:a}) = 1

julia> f(::Val{:b}) = "test"

julia> f(::Val{:c}) = 2.4

julia> f(@nospecialize(x)) = error("$x is not supported.")

julia> function g(x::Symbol)
           if x === :a
               return 1
           elseif x === :b
               return "test"
           elseif x === :c
               return 2.4
           else
               error("$x is not supported.")
           end
       end

julia> @be rand([:a, :b, :c]) f
Benchmark: 2236 samples with 572 evaluations
 min    45.892 ns (<0.01 allocs: 0.196 bytes)
 median 50.407 ns (<0.01 allocs: 0.196 bytes)
 mean   51.162 ns (<0.01 allocs: 0.196 bytes)
 max    151.806 ns (<0.01 allocs: 0.196 bytes)

julia> @be rand([:a, :b, :c]) g
Benchmark: 3178 samples with 8368 evaluations
 min    2.594 ns (<0.01 allocs: 0.013 bytes)
 median 2.988 ns (<0.01 allocs: 0.013 bytes)
 mean   3.008 ns (<0.01 allocs: 0.013 bytes)
 max    5.492 ns (<0.01 allocs: 0.013 bytes)
```