### PR TITLE
Rename testset to avoid that it's overwritten by ReTest

### DIFF
--- a/test/hamiltonian.jl
+++ b/test/hamiltonian.jl
@@ -38,7 +38,7 @@ end
     end
 end
 
-@testset "Metric" begin
+@testset "Energy" begin
     n_tests = 10
 
     for T in [Float32, Float64]

--- a/test/metric.jl
+++ b/test/metric.jl
@@ -10,7 +10,7 @@ using ReTest, Random, AdvancedHMC
             DiagEuclideanMetric((D, n_chains)),
             # DenseEuclideanMetric((D, n_chains)) # not supported ATM
         ]
-            r = rand(rng, metric)
+            r = rand(rng, metric, GaussianKinetic())
             all_same = true
             for i = 2:n_chains
                 all_same = all_same && r[:, i] == r[:, 1]


### PR DESCRIPTION
There's another testset in metric.jl of the same name. Fixes warnings such as https://github.com/TuringLang/AdvancedHMC.jl/actions/runs/13408088109/job/37451777320?pr=395#step:6:921

Edit: This actually uncovered a bug in the test.