### PR TITLE
Ignore formatting commit in git-blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Initial formatting: https://github.com/TuringLang/AdvancedHMC.jl/pull/404
+0de135e37d103eda3d09bc4af9019bcecb71a959


### PR DESCRIPTION
See https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view