### PR TITLE
Add examples for AD backend switching

### DIFF
--- a/docs/src/autodiff.md
+++ b/docs/src/autodiff.md
@@ -1,12 +1,11 @@
 # Gradient in AdvancedHMC.jl
 
-AdvancedHMC.jl supports automatic differentiation using [`LogDensityProblemsAD`](https://github.com/tpapp/LogDensityProblemsAD.jl) across various AD backends and allows user-specified gradients. While the default AD backend for AdvancedHMC.jl is ForwardDiff.jl, we can seamlessly change to other backend like Mooncake.jl using various syntax like `Hamiltonian(metric, ℓπ, AutoMooncake(; config = nothing))`. Different AD backend can also be pluged in using `Hamiltonian(metric, ℓπ, Zygote)`, `Hamiltonian(metric, ℓπ, Val(:Zygote))` but we recommend using ADTypes since that would allow you to have more freedom for specifying the AD backend.
+AdvancedHMC.jl supports automatic differentiation using [`LogDensityProblemsAD`](https://github.com/tpapp/LogDensityProblemsAD.jl) across various AD backends and allows user-specified gradients. While the default AD backend for AdvancedHMC.jl is ForwardDiff.jl, we can seamlessly change to other backend like Mooncake.jl using various syntax like `Hamiltonian(metric, ℓπ, AutoMooncake(; config = nothing))`. While some AD backend support syntax like `Hamiltonian(metric, ℓπ, Zygote)`, `Hamiltonian(metric, ℓπ, Val(:Zygote))`, we recommend using ADTypes since that would allow you to have more freedom for specifying the AD backend:
 
 ```julia
-using AdvancedHMC, DifferentiationInterface, Mooncake, Zygote
+using AdvancedHMC, ADTypes, DifferentiationInterface, Mooncake, Zygote
 hamiltonian = Hamiltonian(metric, ℓπ, AutoMooncake(; config=nothing))
-hamiltonian = Hamiltonian(metric, ℓπ, Zygote)
-hamiltonian = Hamiltonian(metric, ℓπ, Val{:Zygote})
+hamiltonian = Hamiltonian(metric, ℓπ, AutoZygote())
 ```
 
 In order to use user-specified gradients, please replace ForwardDiff.jl with `ℓπ_grad` in the `Hamiltonian` constructor as `Hamiltonian(metric, ℓπ, ℓπ_grad)`, where the gradient function `ℓπ_grad` should return a tuple containing both the log-posterior and its gradient, for example `ℓπ_grad(x) = (log_posterior, grad)`.

--- a/docs/src/autodiff.md
+++ b/docs/src/autodiff.md
@@ -1,6 +1,6 @@
 # Gradient in AdvancedHMC.jl
 
-AdvancedHMC.jl supports automatic differentiation using [`LogDensityProblemsAD`](https://github.com/tpapp/LogDensityProblemsAD.jl) across various AD backends and allows user-specified gradients. While the default AD backend for AdvancedHMC.jl is ForwardDiff.jl, we can seamlessly change to other backend like Mooncake.jl using various syntax like `Hamiltonian(metric, ℓπ, AutoMooncake(; config = nothing))`. While some AD backend support syntax like `Hamiltonian(metric, ℓπ, Zygote)`, `Hamiltonian(metric, ℓπ, Val(:Zygote))`, we recommend using ADTypes since that would allow you to have more freedom for specifying the AD backend:
+AdvancedHMC.jl supports automatic differentiation using [`LogDensityProblemsAD`](https://github.com/tpapp/LogDensityProblemsAD.jl) across various AD backends and allows user-specified gradients. While the default AD backend for AdvancedHMC.jl is ForwardDiff.jl, we can seamlessly change to other backend like Mooncake.jl using various syntax like `Hamiltonian(metric, ℓπ, AutoMooncake(; config = nothing))`. While some AD backends support syntax like `Hamiltonian(metric, ℓπ, Zygote)`, `Hamiltonian(metric, ℓπ, Val(:Zygote))`, we recommend using ADTypes since that would allow you to have more freedom for specifying the AD backend:
 
 ```julia
 using AdvancedHMC, ADTypes, DifferentiationInterface, Mooncake, Zygote

--- a/docs/src/autodiff.md
+++ b/docs/src/autodiff.md
@@ -1,5 +1,12 @@
 # Gradient in AdvancedHMC.jl
 
-AdvancedHMC.jl supports automatic differentiation using [`LogDensityProblemsAD`](https://github.com/tpapp/LogDensityProblemsAD.jl) across various AD backends and allows user-specified gradients. While the default AD backend for AdvancedHMC.jl is ForwardDiff.jl, we can seamlessly change to other backend like Mooncake.jl using various syntax like `Hamiltonian(metric, ℓπ, AutoZygote())`. Different AD backend can also be pluged in using `Hamiltonian(metric, ℓπ, Zygote)`, `Hamiltonian(metric, ℓπ, Val(:Zygote))` but we recommend using ADTypes since that would allow you to have more freedom for specifying the AD backend.
+AdvancedHMC.jl supports automatic differentiation using [`LogDensityProblemsAD`](https://github.com/tpapp/LogDensityProblemsAD.jl) across various AD backends and allows user-specified gradients. While the default AD backend for AdvancedHMC.jl is ForwardDiff.jl, we can seamlessly change to other backend like Mooncake.jl using various syntax like `Hamiltonian(metric, ℓπ, AutoMooncake(; config = nothing))`. Different AD backend can also be pluged in using `Hamiltonian(metric, ℓπ, Zygote)`, `Hamiltonian(metric, ℓπ, Val(:Zygote))` but we recommend using ADTypes since that would allow you to have more freedom for specifying the AD backend.
+
+```julia
+using AdvancedHMC, DifferentiationInterface, Mooncake, Zygote
+hamiltonian = Hamiltonian(metric, ℓπ, AutoMooncake(; config=nothing))
+hamiltonian = Hamiltonian(metric, ℓπ, Zygote)
+hamiltonian = Hamiltonian(metric, ℓπ, Val{:Zygote})
+```
 
 In order to use user-specified gradients, please replace ForwardDiff.jl with `ℓπ_grad` in the `Hamiltonian` constructor as `Hamiltonian(metric, ℓπ, ℓπ_grad)`, where the gradient function `ℓπ_grad` should return a tuple containing both the log-posterior and its gradient, for example `ℓπ_grad(x) = (log_posterior, grad)`.


### PR DESCRIPTION
Fix: #422 

Since Mooncake requires manually setting `config`, our Hamiltonian doesn't support using Module or `Val` like `Hamiltonian(metric, ℓπ, Mooncake)` or `Hamiltonian(metric, ℓπ, Val{:Mooncake})`, so the example uses Zygote for these syntax