### PR TITLE
Fix gradient length mismatch in PhasePoint

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -59,9 +59,9 @@ struct PhasePoint{T<:AbstractVecOrMat{<:AbstractFloat},V<:DualValue}
     θ::T  # Position variables / model parameters.
     r::T  # Momentum variables
     ℓπ::V # Cached neg potential energy for the current θ.
-    ℓκ::V # Cached neg kinect energy for the current r.
+    ℓκ::V # Cached neg kinetic energy for the current r.
     function PhasePoint(θ::T, r::T, ℓπ::V, ℓκ::V) where {T,V}
-        @argcheck length(θ) == length(r) == length(ℓπ.gradient) == length(ℓπ.gradient)
+        @argcheck length(θ) == length(r) == length(ℓπ.gradient) == length(ℓκ.gradient)
         if !isfinite(ℓπ)
             ℓπ = DualValue(
                 map(v -> isfinite(v) ? v : oftype(v, -Inf), ℓπ.value), ℓπ.gradient

--- a/test/hamiltonian.jl
+++ b/test/hamiltonian.jl
@@ -39,6 +39,14 @@ end
 
         @test z1.ℓπ.value == z2.ℓπ.value
         @test z1.ℓκ.value == z2.ℓκ.value
+
+        # Test gradient length mismatch of neg potential and kinetic energy in PhasePoint
+        @test_throws ArgumentError PhasePoint(
+            [T(Inf)],
+            [T(Inf)],
+            DualValue(zero(T), [zero(T)]),
+            DualValue(zero(T), zeros(T, 2)),
+        )
     end
 end
 


### PR DESCRIPTION
Part of #344