### PR TITLE
Reduce allocation in mass matrix adaptor

### DIFF
--- a/src/adaptation/massmatrix.jl
+++ b/src/adaptation/massmatrix.jl
@@ -214,13 +214,13 @@ end
 WelfordCov(sz::Tuple{Int}; kwargs...) = WelfordCov{Float64}(sz; kwargs...)
 
 function Base.resize!(wc::WelfordCov, θ::AbstractVector{T}) where {T<:AbstractFloat}
-    if length(θ) != size(wc.cov, 1)
+    n = length(θ)
+    if n != size(wc.cov, 1)
         @assert wc.n == 0 "Cannot resize a var estimator when it contains samples."
-        n = length(θ)
         __fill!(wc.μ, n, T(0))
         __fill!(wc.δ, n, T(0))
-        wc.M = zeros(T, length(θ), length(θ))
-        wc.cov = LinearAlgebra.diagm(0 => ones(T, length(θ)))
+        wc.M = zeros(T, n, n)
+        wc.cov = LinearAlgebra.diagm(0 => ones(T, n))
     end
 end
 

--- a/src/adaptation/stan_adaptor.jl
+++ b/src/adaptation/stan_adaptor.jl
@@ -117,7 +117,7 @@ function adapt!(
 
     adapt!(tp.ssa, θ, α)
 
-    resize!(tp.pc, θ) # Resize pre-conditioner if necessary.
+    resize_with!(tp.pc, θ) # Resize pre-conditioner if necessary.
 
     # Ref: https://github.com/stan-dev/stan/blob/develop/src/stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp
     if is_in_window(tp)


### PR DESCRIPTION
Instead of allocating using `zeros` and `ones` when resizing the adaptor, we can directly use in-place operations like `resize!` and `fill!` to reduce allocations.