### PR TITLE
Add RankUpdateEuclideanMetric

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -8,6 +8,7 @@ This modularity means that different HMC variants can be easily constructed by c
   - Unit metric: `UnitEuclideanMetric(dim)`
   - Diagonal metric: `DiagEuclideanMetric(dim)`
   - Dense metric: `DenseEuclideanMetric(dim)`
+  - Rank update metric: `RankUpdateEuclideanMetric(dim)`
 
 where `dim` is the dimensionality of the sampling space.
 

--- a/src/AdvancedHMC.jl
+++ b/src/AdvancedHMC.jl
@@ -2,7 +2,18 @@ module AdvancedHMC
 
 using Statistics: mean, var, middle
 using LinearAlgebra:
-    Symmetric, UpperTriangular, mul!, ldiv!, dot, I, diag, cholesky, UniformScaling
+    Symmetric,
+    UpperTriangular,
+    mul!,
+    ldiv!,
+    dot,
+    I,
+    diag,
+    cholesky,
+    UniformScaling,
+    Diagonal,
+    qr,
+    lmul!
 using StatsFuns: logaddexp, logsumexp, loghalf
 using Random: Random, AbstractRNG
 using ProgressMeter: ProgressMeter
@@ -40,7 +51,8 @@ struct GaussianKinetic <: AbstractKinetic end
 export GaussianKinetic
 
 include("metric.jl")
-export UnitEuclideanMetric, DiagEuclideanMetric, DenseEuclideanMetric
+export UnitEuclideanMetric,
+    DiagEuclideanMetric, DenseEuclideanMetric, RankUpdateEuclideanMetric
 
 include("hamiltonian.jl")
 export Hamiltonian

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -61,6 +61,18 @@ function ∂H∂r(h::Hamiltonian{<:DenseEuclideanMetric,<:GaussianKinetic}, r::A
     return M⁻¹ * r
 end
 
+function ∂H∂r(
+    h::Hamiltonian{<:RankUpdateEuclideanMetric,<:GaussianKinetic}, r::AbstractVecOrMat
+)
+    (; M⁻¹) = h.metric
+    axes_M⁻¹ = __axes(M⁻¹)
+    axes_r = __axes(r)
+    (first(axes_M⁻¹) !== first(axes_r)) && throw(
+        ArgumentError("AxesMismatch: M⁻¹ has axes $(axes_M⁻¹) but r has axes $(axes_r)")
+    )
+    return M⁻¹ * r
+end
+
 # TODO (kai) make the order of θ and r consistent with neg_energy
 # TODO (kai) add stricter types to block hamiltonian.jl#L37 from working on unknown metric/kinetic
 # The gradient of a position-dependent Hamiltonian system depends on both θ and r. 
@@ -163,6 +175,13 @@ function neg_energy(
 ) where {T<:AbstractVecOrMat}
     mul!(h.metric._temp, h.metric.M⁻¹, r)
     return -dot(r, h.metric._temp) / 2
+end
+
+function neg_energy(
+    h::Hamiltonian{<:RankUpdateEuclideanMetric,<:GaussianKinetic}, r::T, θ::T
+) where {T<:AbstractVecOrMat}
+    M⁻¹ = h.metric.M⁻¹
+    return -r' * M⁻¹ * r / 2
 end
 
 energy(args...) = -neg_energy(args...)

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -153,7 +153,7 @@ RankUpdateEuclideanMetric(sz::Tuple{Int}) = RankUpdateEuclideanMetric(Float64, s
 
 AdvancedHMC.renew(::RankUpdateEuclideanMetric, M⁻¹) = RankUpdateEuclideanMetric(M⁻¹)
 
-Base.size(metric::RankUpdateEuclideanMetric, dim...) = size(metric.M⁻¹, dim...)
+Base.size(metric::RankUpdateEuclideanMetric, dim...) = size(metric.M⁻¹.diag, dim...)
 
 function Base.show(io::IO, metric::RankUpdateEuclideanMetric)
     print(io, "RankUpdateEuclideanMetric(diag=$(diag(metric.M⁻¹)))")

--- a/test/metric.jl
+++ b/test/metric.jl
@@ -10,6 +10,7 @@ using ReTest, Random, AdvancedHMC
             UnitEuclideanMetric((D, n_chains)),
             DiagEuclideanMetric((D, n_chains)),
             # DenseEuclideanMetric((D, n_chains)) # not supported ATM
+            # RankUpdateEuclideanMetric((D, n_chains)) # not supported ATM
         ]
             r = AdvancedHMC.rand_momentum(rng, metric, GaussianKinetic(), θ)
             all_same = true
@@ -25,8 +26,12 @@ using ReTest, Random, AdvancedHMC
         rng = MersenneTwister(1)
         θ = randn(rng, D)
         ℓπ(θ) = 1
-        for metric in
-            [UnitEuclideanMetric(1), DiagEuclideanMetric(1), DenseEuclideanMetric(1)]
+        for metric in [
+            UnitEuclideanMetric(1),
+            DiagEuclideanMetric(1),
+            DenseEuclideanMetric(1),
+            RankUpdateEuclideanMetric(1),
+        ]
             h = Hamiltonian(metric, ℓπ, ℓπ)
             h = AdvancedHMC.resize(h, θ)
             @test size(h.metric) == size(θ)

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -62,6 +62,7 @@ end
         :UnitEuclideanMetric => UnitEuclideanMetric(D),
         :DiagEuclideanMetric => DiagEuclideanMetric(D),
         :DenseEuclideanMetric => DenseEuclideanMetric(D),
+        :RankUpdateEuclideanMetric => RankUpdateEuclideanMetric(D),
     )
         h = Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
         @testset "$lfsym" for (lfsym, lf) in Dict(
@@ -102,6 +103,11 @@ end
                         h, HMCKernel(τ), θ_init, n_samples; verbose=false, progress=PROGRESS
                     )
                     @test mean(samples) ≈ zeros(D) atol = RNDATOL
+                end
+
+                if metricsym == :RankUpdateEuclideanMetric
+                    # Skip tests with `RankUpdateEuclideanMetric` for `MassMatrixAdaptor`
+                    continue
                 end
 
                 @testset "$adaptorsym" for (adaptorsym, adaptor) in Dict(


### PR DESCRIPTION
Fix: #411
Part of #277

This PR ports `RankUpdateEuclideanMetric` from Pathfinder.jl, but don't depend on PDMats.jl, see why not use PDMats.jl in #34.

With this metric in, we can take a step forward low-rank metric adaption, and Pathfinder.jl can directly use this metric from AHMC without unsafe overloading.