### PR TITLE
Run tests with Julia 1.10.0 on macOS-latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,12 +30,6 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        exclude:
-          - version: 'min'
-            os: macOS-latest # Apple Silicon
-        include:
-          - version: 'min'
-            os: macOS-13 # Intel
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
Since the Julia compat was bumped to 1.10.0, there's no reason anymore for special-casing the CI setup on mac runners. It only existed since some previous Julia versions are not available for Apple silicon.