### PR TITLE
No string interpolation in `show` methods

### DIFF
--- a/src/adaptation/Adaptation.jl
+++ b/src/adaptation/Adaptation.jl
@@ -38,7 +38,7 @@ struct NaiveHMCAdaptor{M<:MassMatrixAdaptor,Tssa<:StepSizeAdaptor} <: AbstractAd
     ssa::Tssa
 end
 function Base.show(io::IO, ::MIME"text/plain", a::NaiveHMCAdaptor)
-    return print(io, "NaiveHMCAdaptor(pc=$(a.pc), ssa=$(a.ssa))")
+    return print(io, "NaiveHMCAdaptor(pc=", a.pc, ", ssa=", a.ssa, ")")
 end
 
 getM⁻¹(ca::NaiveHMCAdaptor) = getM⁻¹(ca.pc)

--- a/src/adaptation/massmatrix.jl
+++ b/src/adaptation/massmatrix.jl
@@ -24,7 +24,7 @@ end
 struct UnitMassMatrix{T<:AbstractFloat} <: MassMatrixAdaptor end
 
 function Base.show(io::IO, mime::MIME"text/plain", ::UnitMassMatrix{T}) where {T}
-    return print(io, "UnitMassMatrix{$T} adaptor")
+    return print(io, "UnitMassMatrix{", T, "} adaptor")
 end
 
 UnitMassMatrix() = UnitMassMatrix{Float64}()
@@ -94,7 +94,7 @@ mutable struct WelfordVar{T<:AbstractFloat,E<:AbstractVecOrMat{T},V<:AbstractVec
 end
 
 function Base.show(io::IO, mime::MIME"text/plain", ::WelfordVar{T}) where {T}
-    return print(io, "WelfordVar{$T} adaptor")
+    return print(io, "WelfordVar{", T, "} adaptor")
 end
 
 function WelfordVar{T}(
@@ -195,7 +195,7 @@ mutable struct WelfordCov{F<:AbstractFloat,C<:AbstractMatrix{F}} <: DenseMatrixE
 end
 
 function Base.show(io::IO, mime::MIME"text/plain", ::WelfordCov{T}) where {T}
-    return print(io, "WelfordCov{$T} adaptor")
+    return print(io, "WelfordCov{", T, "} adaptor")
 end
 
 function WelfordCov{T}(

--- a/src/adaptation/stan_adaptor.jl
+++ b/src/adaptation/stan_adaptor.jl
@@ -50,12 +50,16 @@ function initialize!(
 end
 
 function Base.show(io::IO, mime::MIME"text/plain", state::StanHMCAdaptorState)
-    return print(
+    print(
         io,
-        "window($(state.window_start), $(state.window_end)), window_splits(" *
-        string(join(state.window_splits, ", ")) *
-        ")",
+        "window(",
+        state.window_start,
+        ", ",
+        state.window_end,
+        "), window_splits(",
     )
+    join(io, state.window_splits, ", ")
+    return print(io, ")")
 end
 
 ### Stan's windowed adaptation
@@ -72,7 +76,19 @@ end
 function Base.show(io::IO, mime::MIME"text/plain", a::StanHMCAdaptor)
     return print(
         io,
-        "StanHMCAdaptor(\n    pc=$(a.pc),\n    ssa=$(a.ssa),\n    init_buffer=$(a.init_buffer), term_buffer=$(a.term_buffer), window_size=$(a.window_size),\n    state=$(a.state)\n)",
+        "StanHMCAdaptor(\n    pc=",
+        a.pc,
+        ",\n    ssa=",
+        a.ssa,
+        ",\n    init_buffer=",
+        a.init_buffer,
+        ", term_buffer=",
+        a.term_buffer,
+        ", window_size=",
+        a.window_size,
+        ",\n    state=",
+        a.state,
+        "\n)",
     )
 end
 

--- a/src/adaptation/stepsize.jl
+++ b/src/adaptation/stepsize.jl
@@ -87,7 +87,7 @@ struct ManualSSAdaptor{T<:AbstractScalarOrVec{<:AbstractFloat}} <: StepSizeAdapt
     state::MSSState{T}
 end
 function Base.show(io::IO, mime::MIME"text/plain", a::ManualSSAdaptor{T}) where {T}
-    return print(io, "ManualSSAdaptor{$T} with step size of $(a.state.ϵ)")
+    return print(io, "ManualSSAdaptor{", T, "} with step size of ", a.state.ϵ)
 end
 
 function ManualSSAdaptor(initϵ::T) where {T<:AbstractScalarOrVec{<:AbstractFloat}}
@@ -122,7 +122,9 @@ end
 function Base.show(io::IO, mime::MIME"text/plain", a::NesterovDualAveraging{T}) where {T}
     return print(
         io,
-        "NesterovDualAveraging{$T} with\n",
+        "NesterovDualAveraging{",
+        T,
+        "} with\n",
         "Scaling γ=",
         a.γ,
         "\n",

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -73,7 +73,7 @@ struct Leapfrog{T<:AbstractScalarOrVec{<:AbstractFloat}} <: AbstractLeapfrog{T}
     ϵ::T
 end
 function Base.show(io::IO, mime::MIME"text/plain", l::Leapfrog)
-    return print(io, "Leapfrog with step size ϵ=$(round.(l.ϵ; sigdigits=3))")
+    return print(io, "Leapfrog with step size ϵ=", round.(l.ϵ; sigdigits=3), ")")
 end
 integrator_eltype(i::AbstractLeapfrog{T}) where {T<:AbstractFloat} = T
 
@@ -123,7 +123,12 @@ JitteredLeapfrog(ϵ0, jitter) = JitteredLeapfrog(ϵ0, jitter, ϵ0)
 function Base.show(io::IO, mime::MIME"text/plain", l::JitteredLeapfrog)
     return print(
         io,
-        "JitteredLeapfrog with step size $(round.(l.ϵ0; sigdigits=3)), jitter $(round.(l.jitter; sigdigits=3)), jittered step size $(round.(l.ϵ; sigdigits=3))",
+        "JitteredLeapfrog with step size ",
+        round.(l.ϵ0; sigdigits=3),
+        ", jitter ",
+        round.(l.jitter; sigdigits=3),
+        ", jittered step size ",
+        round.(l.ϵ; sigdigits=3),
     )
 end
 
@@ -176,7 +181,10 @@ end
 function Base.show(io::IO, mime::MIME"text/plain", l::TemperedLeapfrog)
     return print(
         io,
-        "TemperedLeapfrog with step size ϵ=$(round.(l.ϵ; sigdigits=3)) and temperature parameter α=$(round.(l.α; sigdigits=3))",
+        "TemperedLeapfrog with step size ϵ=",
+        round.(l.ϵ; sigdigits=3),
+        " and temperature parameter α=",
+        round.(l.α; sigdigits=3),
     )
 end
 

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -36,7 +36,11 @@ Base.size(e::UnitEuclideanMetric, dim::Int) = e.size[dim]
 function Base.show(io::IO, ::MIME"text/plain", uem::UnitEuclideanMetric{T}) where {T}
     return print(
         io,
-        "UnitEuclideanMetric{$T} with size $(size(uem)) mass matrix:\n",
+        "UnitEuclideanMetric{",
+        T,
+        "} with size ",
+        size(uem),
+        " mass matrix:\n",
         _string_M⁻¹(ones(uem.size)),
     )
 end
@@ -65,7 +69,11 @@ Base.size(e::DiagEuclideanMetric, dim...) = size(e.M⁻¹, dim...)
 function Base.show(io::IO, ::MIME"text/plain", dem::DiagEuclideanMetric{T}) where {T}
     return print(
         io,
-        "DiagEuclideanMetric{$T} with size $(size(dem)) mass matrix:\n",
+        "DiagEuclideanMetric{",
+        T,
+        "} with size ",
+        size(dem),
+        " mass matrix:\n",
         _string_M⁻¹(dem.M⁻¹),
     )
 end
@@ -105,7 +113,11 @@ Base.size(e::DenseEuclideanMetric, dim...) = size(e._temp, dim...)
 function Base.show(io::IO, ::MIME"text/plain", dem::DenseEuclideanMetric{T}) where {T}
     return print(
         io,
-        "DenseEuclideanMetric{$T} with size $(size(dem)) mass matrix:\n",
+        "DenseEuclideanMetric{",
+        T,
+        "} with size ",
+        size(dem),
+        " mass matrix:\n",
         _string_M⁻¹(dem.M⁻¹),
     )
 end

--- a/src/riemannian/hamiltonian.jl
+++ b/src/riemannian/hamiltonian.jl
@@ -20,7 +20,7 @@ struct GeneralizedLeapfrog{T<:AbstractScalarOrVec{<:AbstractFloat}} <: AbstractL
     n::Int
 end
 function Base.show(io::IO, l::GeneralizedLeapfrog)
-    return print(io, "GeneralizedLeapfrog(ϵ=$(round.(l.ϵ; sigdigits=3)), n=$(l.n))")
+    return print(io, "GeneralizedLeapfrog(ϵ=", round.(l.ϵ; sigdigits=3), ", n=", l.n, ")")
 end
 
 # Fallback to ignore return_cache & cache kwargs for other ∂H∂θ

--- a/src/riemannian/integrator.jl
+++ b/src/riemannian/integrator.jl
@@ -18,7 +18,7 @@ struct GeneralizedLeapfrog{T<:AbstractScalarOrVec{<:AbstractFloat}} <: AbstractL
     n::Int
 end
 function Base.show(io::IO, l::GeneralizedLeapfrog)
-    return print(io, "GeneralizedLeapfrog(ϵ=$(round.(l.ϵ; sigdigits=3)), n=$(l.n))")
+    return print(io, "GeneralizedLeapfrog(ϵ=", round.(l.ϵ; sigdigits=3), ", n=", l.n, ")")
 end
 
 # fallback to ignore return_cache & cache kwargs for other ∂H∂θ

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -111,7 +111,10 @@ end
 function Base.show(io::IO, mime::MIME"text/plain", s::SliceTS)
     return print(
         io,
-        "SliceTS with slice variable ℓu=$(s.ℓu) and number of acceptable candiadtes n=$(s.n)",
+        "SliceTS with slice variable ℓu=",
+        s.ℓu,
+        " and number of acceptable candiadtes n=",
+        s.n,
     )
 end
 
@@ -225,7 +228,12 @@ ConstructionBase.constructorof(::Type{<:Trajectory{TS}}) where {TS} = Trajectory
 function Base.show(io::IO, mime::MIME"text/plain", τ::Trajectory{TS}) where {TS}
     return print(
         io,
-        "Trajectory{$TS} with $(τ.integrator) and termination criterion $(τ.termination_criterion)",
+        "Trajectory{",
+        TS,
+        "} with ",
+        τ.integrator,
+        " and termination criterion ",
+        τ.termination_criterion,
     )
 end
 
@@ -476,7 +484,12 @@ end
 
 function Base.show(io::IO, mime::MIME"text/plain", d::Termination)
     return print(
-        io, "Termination reasons of (dynamic=$(d.dynamic), numerical=$(d.numerical))"
+        io,
+        "Termination reasons of (dynamic=",
+        d.dynamic,
+        ", numerical=",
+        d.numerical,
+        ")",
     )
 end
 function Base.:*(d1::Termination, d2::Termination)


### PR DESCRIPTION
String interpolation in `show` methods (many instances recently introduced in https://github.com/TuringLang/AdvancedHMC.jl/pull/446) is unnecessary. The Julia docs even explicitly advise against it: https://docs.julialang.org/en/v1/manual/performance-tips/#Avoid-string-interpolation-for-I/O