### PR TITLE
Fix order of keys and values in progress meter

### DIFF
--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -94,7 +94,7 @@ end
 Progress meter update with all trajectory stats, iteration number and metric shown.
 """
 function pm_next!(pm, stat::NamedTuple)
-    ProgressMeter.next!(pm; showvalues=map(tuple, values(stat), keys(stat)))
+    ProgressMeter.next!(pm; showvalues=map(tuple, keys(stat), values(stat)))
     return nothing
 end
 


### PR DESCRIPTION
As prior to https://github.com/TuringLang/AdvancedHMC.jl/commit/d90910ed1252007001f46a17dd18e002f089b8f4 and as done in other packages, IMO it is more natural to print "key: value" instead of "value: key".