### PR TITLE
Fix #411: Make `rand_momentum` part of the public API

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # AdvancedHMC Changelog
 
+## 0.8.5
+
+  - `rand_momentum(rng, metric, kinetic, θ)` is now part of the public API (exported).
+    Packages that extend AdvancedHMC with custom metric types can implement this method
+    without depending on an internal symbol.
+
 ## 0.8.4
 
   - Introduces an experimental way to improve the *diagonal* mass matrix adaptation using gradient information (similar to [nutpie](https://github.com/pymc-devs/nutpie)),

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedHMC"
 uuid = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
-version = "0.8.4"
+version = "0.8.5"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/AdvancedHMC.jl
+++ b/src/AdvancedHMC.jl
@@ -40,7 +40,7 @@ struct GaussianKinetic <: AbstractKinetic end
 export GaussianKinetic
 
 include("metric.jl")
-export UnitEuclideanMetric, DiagEuclideanMetric, DenseEuclideanMetric
+export UnitEuclideanMetric, DiagEuclideanMetric, DenseEuclideanMetric, rand_momentum
 
 include("hamiltonian.jl")
 export Hamiltonian


### PR DESCRIPTION
Look simple enough, but we may want to do more, see comments below.

*Human content above*

---

*Claude content below*

## Make `rand_momentum` part of the public API

### Problem

`rand_momentum` is an internal function used to sample momentum variables from a given metric and kinetic energy type. Packages that extend AdvancedHMC with custom metric types (e.g. Pathfinder.jl's `RankUpdateEuclideanMetric`) need to implement their own `rand_momentum` method, but because the function is not exported, they depend on an undocumented internal.

### Change

One line added to `src/AdvancedHMC.jl`:

```julia
export UnitEuclideanMetric, DiagEuclideanMetric, DenseEuclideanMetric, rand_momentum
```

### MWE

See `411-rand-momentum-api.jl`. Checks that `:rand_momentum ∈ names(AdvancedHMC)` and that the function is callable. Fails on `main` with `UndefVarError`.

### Notes

- No behavior change — the function already exists and is fully implemented for all three built-in metric types plus the Riemannian metric.
- Signature: `rand_momentum(rng, metric, kinetic, θ)` — the `θ` argument is ignored for Euclidean metrics but present for position-dependent (Riemannian) ones.
- Maintainer already confirmed willingness to export in the issue comments.


## MWE

### `411-rand-momentum-api.jl`

````julia
# MWE for https://github.com/TuringLang/AdvancedHMC.jl/issues/411
# Fails on main (rand_momentum not exported), exits 0 after fix.

using AdvancedHMC, Random

# rand_momentum must appear in the public API (exported names)
if :rand_momentum ∉ names(AdvancedHMC)
    @error "rand_momentum is not exported from AdvancedHMC"
    exit(1)
end

# Must also be callable
metric  = DiagEuclideanMetric(Float64, 2)
kinetic = GaussianKinetic()
r = rand_momentum(Random.default_rng(), metric, kinetic, zeros(2))
@assert r isa AbstractVector{Float64} && length(r) == 2

````

**main output:**
````
# MWE: 411-rand-momentum-api.jl on main
# started: 2026-03-19 20:01:33
# dir: /home/niko/github/issues/AdvancedHMC.jl
---
==> Pkg.instantiate()
==> Running 411-rand-momentum-api.jl
┌ Error: rand_momentum is not exported from AdvancedHMC
└ @ Main ~/github/issues/AdvancedHMC/proposals/411-rand-momentum-api.jl:8

# exit_code: 1
# status: FAIL
# finished: 2026-03-19 20:01:50

````

**worktree output:**
````
# MWE: 411-rand-momentum-api.jl on worktree
# started: 2026-03-19 20:01:33
# dir: /home/niko/github/issues/AdvancedHMC/worktrees/issue-411-rand-momentum-api
---
==> Pkg.instantiate()
Precompiling packages...
    AdvancedHMC Being precompiled by another process (pid: 2096748, pidfile: /home/niko/.julia/compiled/v1.10/AdvancedHMC/WaglY_80WTF.ji.pidfile)
  10520.0 ms  ✓ AdvancedHMC
  1 dependency successfully precompiled in 17 seconds. 69 already precompiled.
==> Running 411-rand-momentum-api.jl

# exit_code: 0
# status: PASS
# finished: 2026-03-19 20:02:02

````

Fixes https://github.com/TuringLang/AdvancedHMC.jl/issues/411
