### PR TITLE
Fix #483: Rename `neg_energy` → `neg_kinetic_energy`

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -67,7 +67,7 @@ function ∂H∂r(h::Hamiltonian{<:DenseEuclideanMetric,<:GaussianKinetic}, r::A
     return M⁻¹ * r
 end
 
-# TODO (kai) make the order of θ and r consistent with neg_energy
+# TODO (kai) make the order of θ and r consistent with neg_kinetic_energy
 # TODO (kai) add stricter types to block hamiltonian.jl#L37 from working on unknown metric/kinetic
 # The gradient of a position-dependent Hamiltonian system depends on both θ and r. 
 ∂H∂θ(h::Hamiltonian, θ::AbstractVecOrMat, r::AbstractVecOrMat) = ∂H∂θ(h, θ)
@@ -101,7 +101,7 @@ function Base.similar(z::PhasePoint{<:AbstractVecOrMat{T}}) where {T<:AbstractFl
 end
 
 function phasepoint(
-    h::Hamiltonian, θ::T, r::T; ℓπ=∂H∂θ(h, θ), ℓκ=DualValue(neg_energy(h, r, θ), ∂H∂r(h, r))
+    h::Hamiltonian, θ::T, r::T; ℓπ=∂H∂θ(h, θ), ℓκ=DualValue(neg_kinetic_energy(h, r, θ), ∂H∂r(h, r))
 ) where {T<:AbstractVecOrMat}
     return PhasePoint(θ, r, ℓπ, ℓκ)
 end
@@ -115,7 +115,7 @@ function phasepoint(
     _r::T2;
     r=safe_rsimilar(θ, _r),
     ℓπ=∂H∂θ(h, θ),
-    ℓκ=DualValue(neg_energy(h, r, θ), ∂H∂r(h, r)),
+    ℓκ=DualValue(neg_kinetic_energy(h, r, θ), ∂H∂r(h, r)),
 ) where {T1<:AbstractVecOrMat,T2<:AbstractVecOrMat}
     return PhasePoint(θ, r, ℓπ, ℓκ)
 end
@@ -140,31 +140,31 @@ neg_energy(h::Hamiltonian, θ::AbstractVecOrMat) = h.ℓπ(θ)
 
 # GaussianKinetic
 
-function neg_energy(
+function neg_kinetic_energy(
     h::Hamiltonian{<:UnitEuclideanMetric,<:GaussianKinetic}, r::T, θ::T
 ) where {T<:AbstractVector}
     return -sum(abs2, r) / 2
 end
 
-function neg_energy(
+function neg_kinetic_energy(
     h::Hamiltonian{<:UnitEuclideanMetric,<:GaussianKinetic}, r::T, θ::T
 ) where {T<:AbstractMatrix}
     return -vec(sum(abs2, r; dims=1)) / 2
 end
 
-function neg_energy(
+function neg_kinetic_energy(
     h::Hamiltonian{<:DiagEuclideanMetric,<:GaussianKinetic}, r::T, θ::T
 ) where {T<:AbstractVector}
     return -sum(abs2.(r) .* h.metric.M⁻¹) / 2
 end
 
-function neg_energy(
+function neg_kinetic_energy(
     h::Hamiltonian{<:DiagEuclideanMetric,<:GaussianKinetic}, r::T, θ::T
 ) where {T<:AbstractMatrix}
     return -vec(sum(abs2.(r) .* h.metric.M⁻¹; dims=1)) / 2
 end
 
-function neg_energy(
+function neg_kinetic_energy(
     h::Hamiltonian{<:DenseEuclideanMetric,<:GaussianKinetic}, r::T, θ::T
 ) where {T<:AbstractVecOrMat}
     mul!(h.metric._temp, h.metric.M⁻¹, r)
@@ -172,6 +172,7 @@ function neg_energy(
 end
 
 energy(args...) = -neg_energy(args...)
+energy(h::Hamiltonian, r::AbstractVecOrMat, θ::AbstractVecOrMat) = -neg_kinetic_energy(h, r, θ)
 
 ####
 #### Momentum refreshment

--- a/src/riemannian/hamiltonian.jl
+++ b/src/riemannian/hamiltonian.jl
@@ -103,7 +103,7 @@ function step(
     return res
 end
 
-# TODO Make the order of θ and r consistent with neg_energy
+# TODO Make the order of θ and r consistent with neg_kinetic_energy
 ∂H∂θ(h::Hamiltonian, θ::AbstractVecOrMat, r::AbstractVecOrMat) = ∂H∂θ(h, θ)
 ∂H∂r(h::Hamiltonian, θ::AbstractVecOrMat, r::AbstractVecOrMat) = ∂H∂r(h, r)
 
@@ -221,7 +221,7 @@ end
 
 ### hamiltonian.jl
 
-import AdvancedHMC: phasepoint, neg_energy, ∂H∂θ, ∂H∂r
+import AdvancedHMC: phasepoint, neg_kinetic_energy, ∂H∂θ, ∂H∂r
 using LinearAlgebra: logabsdet, tr
 
 # QUES Do we want to change everything to position dependent by default?
@@ -231,14 +231,14 @@ function phasepoint(
     θ::T,
     r::T;
     ℓπ=∂H∂θ(h, θ),
-    ℓκ=DualValue(neg_energy(h, r, θ), ∂H∂r(h, θ, r)),
+    ℓκ=DualValue(neg_kinetic_energy(h, r, θ), ∂H∂r(h, θ, r)),
 ) where {T<:AbstractVecOrMat}
     return PhasePoint(θ, r, ℓπ, ℓκ)
 end
 
 # Negative kinetic energy
 #! Eq (13) of Girolami & Calderhead (2011)
-function neg_energy(
+function neg_kinetic_energy(
     h::Hamiltonian{<:DenseRiemannianMetric}, r::T, θ::T
 ) where {T<:AbstractVecOrMat}
     G = h.metric.map(h.metric.G(θ))

--- a/test/hamiltonian.jl
+++ b/test/hamiltonian.jl
@@ -60,19 +60,19 @@ end
             r_init = randn(T, D)
 
             h = Hamiltonian(UnitEuclideanMetric(T, D), ℓπ, ∂ℓπ∂θ)
-            @test -AdvancedHMC.neg_energy(h, r_init, θ_init) == sum(abs2, r_init) / 2
+            @test -AdvancedHMC.neg_kinetic_energy(h, r_init, θ_init) == sum(abs2, r_init) / 2
             @test AdvancedHMC.∂H∂r(h, r_init) == r_init
 
             M⁻¹ = ones(T, D) + abs.(randn(T, D))
             h = Hamiltonian(DiagEuclideanMetric(M⁻¹), ℓπ, ∂ℓπ∂θ)
-            @test -AdvancedHMC.neg_energy(h, r_init, θ_init) ≈
+            @test -AdvancedHMC.neg_kinetic_energy(h, r_init, θ_init) ≈
                 r_init' * diagm(0 => M⁻¹) * r_init / 2
             @test AdvancedHMC.∂H∂r(h, r_init) == M⁻¹ .* r_init
 
             m = randn(T, D, D)
             M⁻¹ = m' * m
             h = Hamiltonian(DenseEuclideanMetric(M⁻¹), ℓπ, ∂ℓπ∂θ)
-            @test -AdvancedHMC.neg_energy(h, r_init, θ_init) ≈ r_init' * M⁻¹ * r_init / 2
+            @test -AdvancedHMC.neg_kinetic_energy(h, r_init, θ_init) ≈ r_init' * M⁻¹ * r_init / 2
             @test AdvancedHMC.∂H∂r(h, r_init) == M⁻¹ * r_init
         end
     end
@@ -86,7 +86,7 @@ end
             r_init = ComponentArray(; a=randn(T, D), b=randn(T, D))
 
             h = Hamiltonian(UnitEuclideanMetric(T, 2 * D), ℓπ, ∂ℓπ∂θ)
-            @test -AdvancedHMC.neg_energy(h, r_init, θ_init) == sum(abs2, r_init) / 2
+            @test -AdvancedHMC.neg_kinetic_energy(h, r_init, θ_init) == sum(abs2, r_init) / 2
             @test AdvancedHMC.∂H∂r(h, r_init) == r_init
             @test typeof(AdvancedHMC.∂H∂r(h, r_init)) == typeof(r_init)
 
@@ -94,7 +94,7 @@ end
                 a=ones(T, D) + abs.(randn(T, D)), b=ones(T, D) + abs.(randn(T, D))
             )
             h = Hamiltonian(DiagEuclideanMetric(M⁻¹), ℓπ, ∂ℓπ∂θ)
-            @test -AdvancedHMC.neg_energy(h, r_init, θ_init) ≈
+            @test -AdvancedHMC.neg_kinetic_energy(h, r_init, θ_init) ≈
                 r_init' * diagm(0 => M⁻¹) * r_init / 2
             @test AdvancedHMC.∂H∂r(h, r_init) == M⁻¹ .* r_init
             @test typeof(AdvancedHMC.∂H∂r(h, r_init)) == typeof(r_init)
@@ -103,7 +103,7 @@ end
             ax = getaxes(r_init)[1]
             M⁻¹ = ComponentArray(m' * m, ax, ax)
             h = Hamiltonian(DenseEuclideanMetric(M⁻¹), ℓπ, ∂ℓπ∂θ)
-            @test -AdvancedHMC.neg_energy(h, r_init, θ_init) ≈ r_init' * M⁻¹ * r_init / 2
+            @test -AdvancedHMC.neg_kinetic_energy(h, r_init, θ_init) ≈ r_init' * M⁻¹ * r_init / 2
             @test all(AdvancedHMC.∂H∂r(h, r_init) .== M⁻¹ * r_init)
             @test typeof(AdvancedHMC.∂H∂r(h, r_init)) == typeof(r_init)
         end

--- a/test/riemannian.jl
+++ b/test/riemannian.jl
@@ -6,7 +6,7 @@ include("../src/riemannian_hmc_utility.jl")
 using FiniteDiff:
     finite_difference_gradient, finite_difference_hessian, finite_difference_jacobian
 using Distributions: MvNormal
-using AdvancedHMC: neg_energy, energy
+using AdvancedHMC: neg_kinetic_energy, energy
 
 # Taken from https://github.com/JuliaDiff/FiniteDiff.jl/blob/master/test/finitedifftests.jl
 δ(a, b) = maximum(abs.(a - b))
@@ -45,7 +45,7 @@ using AdvancedHMC: neg_energy, energy
                 all(iszero, x) # or for x==0 that I know it's PD
                 @testset "Kinetic energy" begin
                     Σ = hamiltonian.metric.map(hamiltonian.metric.G(x))
-                    @test neg_energy(hamiltonian, r, x) ≈ logpdf(MvNormal(zeros(D), Σ), r)
+                    @test neg_kinetic_energy(hamiltonian, r, x) ≈ logpdf(MvNormal(zeros(D), Σ), r)
                 end
             end
 


### PR DESCRIPTION
I'll check the changes before marking it as ready for review.

*Human content above*

---

*Claude content below*

## Rename `neg_energy` → `neg_kinetic_energy`

### Problem

`neg_energy` is overloaded with three distinct meanings:

- `neg_energy(z::PhasePoint)` → total negative Hamiltonian energy (ℓπ + ℓκ)
- `neg_energy(h, θ)` → negative potential energy (log density)
- `neg_energy(h, r, θ)` → negative **kinetic** energy

The third overload (the one taking momentum `r`) is the confusing one: internally it is cached as `ℓκ` (the "neg kinetic energy") in `PhasePoint`, and the Riemannian code even has a comment `# Negative kinetic energy` directly above its definition. The naming mismatch makes it hard to understand what `phasepoint(h, θ, r)` is actually caching.

### Change

4 files changed (21 insertions, 20 deletions):

- **`src/hamiltonian.jl`** — rename 5 `neg_energy(h, r, θ)` definitions to `neg_kinetic_energy`; update the two `phasepoint` call sites; add explicit `energy(h, r, θ)` dispatch that routes to `neg_kinetic_energy` (the `energy(args...)` catch-all can no longer reach the renamed function)
- **`src/riemannian/hamiltonian.jl`** — rename the 6th kinetic overload (Riemannian metric); update import and `phasepoint` call site
- **`test/hamiltonian.jl`** — update 6 test assertions
- **`test/riemannian.jl`** — update import and 1 assertion

### MWE

See `483-rename-neg-kinetic-energy.jl`. Checks that `AdvancedHMC.neg_kinetic_energy` is defined and callable, and that `neg_energy(z::PhasePoint)` still works. Fails on `main` because `neg_kinetic_energy` does not exist.

### Notes

- `neg_energy(z::PhasePoint)` and `neg_energy(h, θ)` are untouched — only the kinetic-energy-specific overloads are renamed.
- The new `energy(h, r, θ)` dispatch preserves the existing `energy` interface used in `test/riemannian.jl`.
- All functions remain internal (not exported).


## MWE

### `483-rename-neg-kinetic-energy.jl`

````julia
# MWE for https://github.com/TuringLang/AdvancedHMC.jl/issues/483
# Fails on main (neg_kinetic_energy does not exist), exits 0 after fix.

using AdvancedHMC, LinearAlgebra

h = Hamiltonian(
    DiagEuclideanMetric(Float64, 2),
    x -> -sum(abs2, x) / 2,
    x -> (-sum(abs2, x) / 2, -x),
)
r, θ = randn(2), randn(2)

# neg_kinetic_energy must exist after the rename
if !isdefined(AdvancedHMC, :neg_kinetic_energy)
    @error "neg_kinetic_energy is not defined in AdvancedHMC"
    exit(1)
end

val = AdvancedHMC.neg_kinetic_energy(h, r, θ)
@assert val isa Real

# The total-energy overload on PhasePoint must still work unchanged
z = AdvancedHMC.phasepoint(h, θ, r)
@assert AdvancedHMC.neg_energy(z) isa Real

````

**main output:**
````
# MWE: 483-rename-neg-kinetic-energy.jl on main
# started: 2026-03-19 20:01:32
# dir: /home/niko/github/issues/AdvancedHMC.jl
---
==> Pkg.instantiate()
==> Running 483-rename-neg-kinetic-energy.jl
┌ Error: neg_kinetic_energy is not defined in AdvancedHMC
└ @ Main ~/github/issues/AdvancedHMC/proposals/483-rename-neg-kinetic-energy.jl:15

# exit_code: 1
# status: FAIL
# finished: 2026-03-19 20:01:53

````

**worktree output:**
````
# MWE: 483-rename-neg-kinetic-energy.jl on worktree
# started: 2026-03-19 20:01:32
# dir: /home/niko/github/issues/AdvancedHMC/worktrees/issue-483-rename-neg-energy
---
==> Pkg.instantiate()
Precompiling packages...
    AdvancedHMC Being precompiled by another process (pid: 2096748, pidfile: /home/niko/.julia/compiled/v1.10/AdvancedHMC/WaglY_80WTF.ji.pidfile)
  31008.7 ms  ✓ AdvancedHMC
  1 dependency successfully precompiled in 35 seconds. 69 already precompiled.
==> Running 483-rename-neg-kinetic-energy.jl

# exit_code: 0
# status: PASS
# finished: 2026-03-19 20:02:18

````

Fixes https://github.com/TuringLang/AdvancedHMC.jl/issues/483
