### PR TITLE
Format code with JuliaFormatter

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,9 +8,9 @@
 ## 0.8.4
 
   - Introduces an experimental way to improve the *diagonal* mass matrix adaptation using gradient information (similar to [nutpie](https://github.com/pymc-devs/nutpie)),
-      currently to be initialized for a `metric` of type `DiagEuclideanMetric`
-      via `mma = AdvancedHMC.NutpieVar(size(metric); var=copy(metric.M⁻¹))`
-      until a new interface is introduced in an upcoming breaking release to specify the method of adaptation.
+    currently to be initialized for a `metric` of type `DiagEuclideanMetric`
+    via `mma = AdvancedHMC.NutpieVar(size(metric); var=copy(metric.M⁻¹))`
+    until a new interface is introduced in an upcoming breaking release to specify the method of adaptation.
 
 ## 0.8.0
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -32,15 +32,15 @@ where `ϵ` is the step size of leapfrog integration.
 ### Adaptor (`adaptor`)
 
   - Adapt the mass matrix `metric` of the Hamiltonian dynamics: `mma = MassMatrixAdaptor(metric)`
-
+    
       + This is lowered to `UnitMassMatrix`, `WelfordVar` or `WelfordCov` based on the type of the mass matrix `metric`
       + There is an experimental way to improve the *diagonal* mass matrix adaptation using gradient information (similar to [nutpie](https://github.com/pymc-devs/nutpie)),
-      currently to be initialized for a `metric` of type `DiagEuclideanMetric`
-      via `mma = AdvancedHMC.NutpieVar(size(metric); var=copy(metric.M⁻¹))`
-      until a new interface is introduced in an upcoming breaking release to specify the method of adaptation.
+        currently to be initialized for a `metric` of type `DiagEuclideanMetric`
+        via `mma = AdvancedHMC.NutpieVar(size(metric); var=copy(metric.M⁻¹))`
+        until a new interface is introduced in an upcoming breaking release to specify the method of adaptation.
 
   - Adapt the step size of the leapfrog integrator `integrator`: `ssa = StepSizeAdaptor(δ, integrator)`
-
+    
       + It uses Nesterov's dual averaging with `δ` as the target acceptance rate.
   - Combine the two above *naively*: `NaiveHMCAdaptor(mma, ssa)`
   - Combine the first two using Stan's windowed adaptation: `StanHMCAdaptor(mma, ssa)`
@@ -65,12 +65,12 @@ sample(
 Draw `n_samples` samples using the kernel `κ` under the Hamiltonian system `h`
 
   - The randomness is controlled by `rng`.
-
+    
       + If `rng` is not provided, the default random number generator (`Random.default_rng()`) will be used.
 
   - The initial point is given by `θ`.
   - The adaptor is set by `adaptor`, for which the default is no adaptation.
-
+    
       + It will perform `n_adapts` steps of adaptation, for which the default is `1_000` or 10% of `n_samples`, whichever is lower.
   - `drop_warmup` specifies whether to drop samples.
   - `verbose` controls the verbosity.

--- a/src/adaptation/Adaptation.jl
+++ b/src/adaptation/Adaptation.jl
@@ -23,7 +23,7 @@ export AbstractAdaptor, adapt!, initialize!, finalize!, reset!, getϵ, getM⁻¹
 
 get_position(x::PhasePoint) = x.θ
 get_position(x::AbstractVecOrMat{<:AbstractFloat}) = x
-const PositionOrPhasePoint = Union{AbstractVecOrMat{<:AbstractFloat}, PhasePoint}
+const PositionOrPhasePoint = Union{AbstractVecOrMat{<:AbstractFloat},PhasePoint}
 
 struct NoAdaptation <: AbstractAdaptor end
 export NoAdaptation

--- a/src/adaptation/massmatrix.jl
+++ b/src/adaptation/massmatrix.jl
@@ -19,7 +19,9 @@ function adapt!(
     return nothing
 end
 
-Base.push!(a::MassMatrixAdaptor, z_or_theta::PositionOrPhasePoint) = push!(a, get_position(z_or_theta))
+function Base.push!(a::MassMatrixAdaptor, z_or_theta::PositionOrPhasePoint)
+    return push!(a, get_position(z_or_theta))
+end
 
 ## Unit mass matrix adaptor
 
@@ -167,7 +169,8 @@ Can be initialized via `NutpieVar(sz)` where `sz` is either a `Tuple{Int}` or a 
 
 $(FIELDS)
 """
-mutable struct NutpieVar{T<:AbstractFloat,E<:AbstractVecOrMat{T},V<:AbstractVecOrMat{T}} <: DiagMatrixEstimator{T}
+mutable struct NutpieVar{T<:AbstractFloat,E<:AbstractVecOrMat{T},V<:AbstractVecOrMat{T}} <:
+               DiagMatrixEstimator{T}
     "Online variance estimator of the posterior positions."
     position_estimator::WelfordVar{T,E,V}
     "Online variance estimator of the posterior gradients."
@@ -182,7 +185,9 @@ mutable struct NutpieVar{T<:AbstractFloat,E<:AbstractVecOrMat{T},V<:AbstractVecO
         return new{eltype(E),E,V}(
             WelfordVar(n, n_min, copy(μ), copy(M), copy(δ), copy(var)),
             WelfordVar(n, n_min, copy(μ), copy(M), copy(δ), copy(var)),
-            n, n_min, var
+            n,
+            n_min,
+            var,
         )
     end
 end
@@ -223,10 +228,12 @@ end
 function reset!(nv::NutpieVar)
     nv.n = 0
     reset!(nv.position_estimator)
-    reset!(nv.gradient_estimator)
+    return reset!(nv.gradient_estimator)
 end
 
-Base.push!(::NutpieVar, x::AbstractVecOrMat{<:AbstractFloat}) = error("`NutpieVar` adaptation requires position and gradient information!")
+function Base.push!(::NutpieVar, x::AbstractVecOrMat{<:AbstractFloat})
+    return error("`NutpieVar` adaptation requires position and gradient information!")
+end
 
 function Base.push!(nv::NutpieVar, z::PhasePoint)
     nv.n += 1
@@ -236,7 +243,11 @@ function Base.push!(nv::NutpieVar, z::PhasePoint)
 end
 
 # Ref: https://github.com/pymc-devs/nutpie
-get_estimation(nv::NutpieVar) = sqrt.(get_estimation(nv.position_estimator) ./ get_estimation(nv.gradient_estimator))
+function get_estimation(nv::NutpieVar)
+    return sqrt.(
+        get_estimation(nv.position_estimator) ./ get_estimation(nv.gradient_estimator)
+    )
+end
 
 ## Dense mass matrix adaptor
 

--- a/src/adaptation/stepsize.jl
+++ b/src/adaptation/stepsize.jl
@@ -121,7 +121,7 @@ struct NesterovDualAveraging{T<:AbstractFloat,S<:AbstractScalarOrVec{T}} <: Step
 end
 
 function Base.show(io::IO, a::NesterovDualAveraging)
-    print(
+    return print(
         io,
         "NesterovDualAveraging(",
         a.γ,

--- a/test/adaptation.jl
+++ b/test/adaptation.jl
@@ -1,8 +1,15 @@
 using ReTest, LinearAlgebra, Distributions, AdvancedHMC, Random, ForwardDiff
-using AdvancedHMC:
-    PhasePoint, DualValue
+using AdvancedHMC: PhasePoint, DualValue
 using AdvancedHMC.Adaptation:
-    DiagMatrixEstimator, WelfordVar, NutpieVar, NaiveVar, WelfordCov, NaiveCov, get_estimation, get_estimation, reset!
+    DiagMatrixEstimator,
+    WelfordVar,
+    NutpieVar,
+    NaiveVar,
+    WelfordCov,
+    NaiveCov,
+    get_estimation,
+    get_estimation,
+    reset!
 
 function runnuts(ℓπ, metric; n_samples=10_000)
     D = size(metric, 1)
@@ -35,7 +42,7 @@ function runnuts_nutpie(ℓπ, metric::DiagEuclideanMetric; n_samples=10_000)
     # Constructing like this until we've settled on a different interface
     adaptor = AdvancedHMC.StanHMCAdaptor(
         AdvancedHMC.Adaptation.NutpieVar(size(metric); var=copy(metric.M⁻¹)),
-        AdvancedHMC.StepSizeAdaptor(nuts.δ, integrator)
+        AdvancedHMC.StepSizeAdaptor(nuts.δ, integrator),
     )
     samples, stats = sample(h, κ, θ_init, n_samples, adaptor, n_adapts; verbose=false)
     return (samples=samples, stats=stats, adaptor=adaptor)
@@ -47,7 +54,8 @@ This is a simple but serviceable proxy for eventual sampling efficiency, but see
 
 (A lower number generally means that the estimated mass matrix is better).
 """
-preconditioned_cond(a::DiagMatrixEstimator, cov::AbstractMatrix) = cond(sqrt(Diagonal(a.var)) \ cov / sqrt(Diagonal(a.var)))
+preconditioned_cond(a::DiagMatrixEstimator, cov::AbstractMatrix) =
+    cond(sqrt(Diagonal(a.var)) \ cov / sqrt(Diagonal(a.var)))
 
 @testset "Adaptation" begin
     Random.seed!(1)
@@ -92,13 +100,11 @@ preconditioned_cond(a::DiagMatrixEstimator, cov::AbstractMatrix) = cond(sqrt(Dia
 
     @testset "MassMatrixAdaptor constructors" begin
         θ = [0.0, 0.0, 0.0, 0.0]
-        z = PhasePoint(
-            θ, θ, DualValue(0., θ), DualValue(0., θ)
-        )
+        z = PhasePoint(θ, θ, DualValue(0.0, θ), DualValue(0.0, θ))
         pc1 = MassMatrixAdaptor(UnitEuclideanMetric) # default dim = 2
         pc2 = MassMatrixAdaptor(DiagEuclideanMetric)
         # Constructing like this until we've settled on a different interface
-        pc2_nutpie = NutpieVar{Float64}((2, ))
+        pc2_nutpie = NutpieVar{Float64}((2,))
         pc3 = MassMatrixAdaptor(DenseEuclideanMetric)
 
         # Var adaptor dimension should be increased to length(θ) from 2
@@ -133,7 +139,7 @@ preconditioned_cond(a::DiagMatrixEstimator, cov::AbstractMatrix) = cond(sqrt(Dia
         )
         # Constructing like this until we've settled on a different interface
         adaptor2_nutpie = StanHMCAdaptor(
-            NutpieVar{Float64}((2, )), NesterovDualAveraging(0.8, 0.5)
+            NutpieVar{Float64}((2,)), NesterovDualAveraging(0.8, 0.5)
         )
         adaptor3 = StanHMCAdaptor(
             MassMatrixAdaptor(DenseEuclideanMetric), NesterovDualAveraging(0.8, 0.5)
@@ -183,7 +189,8 @@ preconditioned_cond(a::DiagMatrixEstimator, cov::AbstractMatrix) = cond(sqrt(Dia
                 # For this target, Nutpie (without regularization) will arrive at the true variances after two draws.
                 res_nutpie = runnuts_nutpie(ℓπ, DiagEuclideanMetric(D))
                 @test res.adaptor.pc.var ≈ σ² rtol = 0.2
-                @test preconditioned_cond(res_nutpie.adaptor.pc, Σ) < preconditioned_cond(res.adaptor.pc, Σ)
+                @test preconditioned_cond(res_nutpie.adaptor.pc, Σ) <
+                    preconditioned_cond(res.adaptor.pc, Σ)
 
                 res = runnuts(ℓπ, DenseEuclideanMetric(D))
                 @test res.adaptor.pc.cov ≈ Diagonal(σ²) rtol = 0.25
@@ -208,7 +215,9 @@ preconditioned_cond(a::DiagMatrixEstimator, cov::AbstractMatrix) = cond(sqrt(Dia
                 # find the best preconditioner for the target.
                 # As these are statistical algorithms, superiority is not always guaranteed, hence this way of testing.
                 res_nutpie = runnuts_nutpie(ℓπ, DiagEuclideanMetric(D))
-                n_nutpie_superior += preconditioned_cond(res_nutpie.adaptor.pc, Σ) < preconditioned_cond(res.adaptor.pc, Σ)
+                n_nutpie_superior +=
+                    preconditioned_cond(res_nutpie.adaptor.pc, Σ) <
+                    preconditioned_cond(res.adaptor.pc, Σ)
 
                 res = runnuts(ℓπ, DenseEuclideanMetric(D))
                 @test res.adaptor.pc.cov ≈ Σ rtol = 0.25


### PR DESCRIPTION
Fixes the failing **Format** CI check on `main`.

Commit `05a7c9a6` (Update Format.yml) activated the formatting gate, which flagged 6 files as unformatted:

- `HISTORY.md`, `docs/src/api.md` — now caught by `format_markdown = true`
- `src/adaptation/Adaptation.jl`, `massmatrix.jl`, `stepsize.jl`, `test/adaptation.jl` — unformatted code left behind by #511

All changes are purely cosmetic (line wrapping, `return` insertion, trailing commas, `Union`/tuple whitespace, markdown list indentation) — produced by JuliaFormatter v1 with the repo's blue style. No logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)