### PR TITLE
Fix default jitter proportion and documentation errors

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ type: software
 license: "MIT"
 repository-code: "https://github.com/TuringLang/AdvancedHMC.jl"
 url: "https://github.com/TuringLang/AdvancedHMC.jl"
-version: "0.8.6"
+version: "0.8.7"
 authors:
   - family-names: "Xu"
     given-names: "Kai"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ type: software
 license: "MIT"
 repository-code: "https://github.com/TuringLang/AdvancedHMC.jl"
 url: "https://github.com/TuringLang/AdvancedHMC.jl"
-version: "0.8.4"
+version: "0.8.6"
 authors:
   - family-names: "Xu"
     given-names: "Kai"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,6 @@ type: software
 license: "MIT"
 repository-code: "https://github.com/TuringLang/AdvancedHMC.jl"
 url: "https://github.com/TuringLang/AdvancedHMC.jl"
-version: "0.8.7"
 authors:
   - family-names: "Xu"
     given-names: "Kai"

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,13 +14,13 @@
 
 ## 0.8.0
 
-  - To make an MCMC transtion from phasepoint `z` using trajectory `τ`(or HMCKernel `κ`) under Hamiltonian `h`, use `transition(h, τ, z)` or `transition(rng, h, τ, z)`(if using HMCKernel, use `transition(h, κ, z)` or `transition(rng, h, κ, z)`).
+  - To make an MCMC transition from phasepoint `z` using trajectory `τ` (or HMCKernel `κ`) under Hamiltonian `h`, use `transition(h, τ, z)` or `transition(rng, h, τ, z)` (if using HMCKernel, use `transition(h, κ, z)` or `transition(rng, h, κ, z)`).
   - The `initial_step_size` in `find_good_stepsize` for heuristic search of a good initial leap-frog step-size can be manually specified, default as `1//10`.
   - The printing interface has been upgraded to a more user-friendly design.
 
 ## v0.7.1
 
-  - README has been simplified, many docs transfered to docs: https://turinglang.org/AdvancedHMC.jl/dev/.
+  - README has been simplified, and much of its content has been transferred to the documentation: https://turinglang.org/AdvancedHMC.jl/dev/.
   - ADTypes.jl can be used for specifying the AD backend in `Hamiltonian(metric, ℓπ, AutoForwardDiff())`.
   - SimpleUnpack.jl and Requires.jl are removed from the dependency.
   - `find_good_stepsize` now has fewer allocations.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # AdvancedHMC Changelog
 
+## 0.8.7
+
+  - Uses a fixed 10% jitter proportion for the `:jitteredleapfrog` convenience constructor.
+
 ## 0.8.6
 
   - Adds `RankUpdateEuclideanMetric`, a Gaussian Euclidean metric whose inverse mass matrix

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedHMC"
 uuid = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
-version = "0.8.6"
+version = "0.8.7"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://turinglang.github.io/AdvancedHMC.jl/dev/)
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
-**AdvancedHMC.jl** provides robust, modular, and efficient implementation of advanced Hamiltonian Monte Carlo (HMC) algorithms in Julia. It is a backend for probabilistic programming languages like [Turing.jl](https://github.com/TuringLang/Turing.jl), but can also be used directly for flexible MCMC sampling when fine-grained control is desired.
+**AdvancedHMC.jl** provides a robust, modular, and efficient implementation of advanced Hamiltonian Monte Carlo (HMC) algorithms in Julia. It is a backend for probabilistic programming languages like [Turing.jl](https://github.com/TuringLang/Turing.jl), but can also be used directly for flexible MCMC sampling when fine-grained control is desired.
 
 **Key Features**
 
@@ -103,7 +103,7 @@ with the following BibTeX entry:
 
 ```
 @inproceedings{xu2020advancedhmc,
-  title={AdvancedHMC. jl: A robust, modular and efficient implementation of advanced HMC algorithms},
+  title={AdvancedHMC.jl: A robust, modular and efficient implementation of advanced HMC algorithms},
   author={Xu, Kai and Ge, Hong and Tebbutt, Will and Tarek, Mohamed and Trapp, Martin and Ghahramani, Zoubin},
   booktitle={Symposium on Advances in Approximate Bayesian Inference},
   pages={1--10},

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -47,7 +47,7 @@ where `ϵ` is the step size of leapfrog integration.
 
 ## The `sample` functions
 
-```julia
+```text
 sample(
     rng::Union{AbstractRNG,AbstractVector{<:AbstractRNG}},
     h::Hamiltonian,

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,7 +1,7 @@
 # Detailed API for AdvancedHMC.jl
 
 An important design goal of AdvancedHMC.jl is modularity; we would like to support algorithmic research on HMC.
-This modularity means that different HMC variants can be easily constructed by composing various components, such as preconditioning metric (i.e., mass matrix), leapfrog integrators, trajectories (static or dynamic), adaption schemes, etc. In this section, we will explain the detailed usage of different modules in AdancedHMC.jl to provide a comprehensive udnerstanding of how AdvancedHMC.jl can achieve both modularity and efficiency. The section highlights the key components of AdvancedHMC.jl, with a complete documentation provided at the end.
+This modularity allows different HMC variants to be constructed by composing components such as a preconditioning metric (i.e. a mass matrix), leapfrog integrators, static or dynamic trajectories, and adaptation schemes. This section explains how these components provide modularity and efficiency. Complete API documentation appears at the end.
 
 ### [Hamiltonian mass matrix (`metric`)](@id hamiltonian_mm)
 
@@ -22,7 +22,7 @@ where `ϵ` is the step size of leapfrog integration.
 
 ### [Kernel (`kernel`)](@id kernel)
 
-  - Static HMC with a fixed number of steps (`n_steps`) from [neal2011mcmc](@Citet): `HMCKernel(Trajectory{EndPointTS}(integrator, FixedNSteps(integrator)))`
+  - Static HMC with a fixed number of steps (`n_steps`) from [neal2011mcmc](@Citet): `HMCKernel(Trajectory{EndPointTS}(integrator, FixedNSteps(n_steps)))`
   - HMC with a fixed total trajectory length (`trajectory_length`) from [neal2011mcmc](@Citet): `HMCKernel(Trajectory{EndPointTS}(integrator, FixedIntegrationTime(trajectory_length)))`
   - Original NUTS with slice sampling from [hoffman2014no](@Citet): `HMCKernel(Trajectory{SliceTS}(integrator, ClassicNoUTurn()))`
   - Generalised NUTS with slice sampling from [betancourt2017conceptual](@Citet): `HMCKernel(Trajectory{SliceTS}(integrator, GeneralisedNoUTurn()))`
@@ -53,9 +53,9 @@ sample(
     h::Hamiltonian,
     κ::HMCKernel,
     θ::AbstractVector{<:AbstractFloat},
-    n_samples::Int;
+    n_samples::Int,
     adaptor::AbstractAdaptor=NoAdaptation(),
-    n_adapts::Int=min(div(n_samples, 10), 1_000),
+    n_adapts::Int=min(div(n_samples, 10), 1_000);
     drop_warmup=false,
     verbose::Bool=true,
     progress::Bool=false,

--- a/docs/src/get_started.md
+++ b/docs/src/get_started.md
@@ -40,8 +40,8 @@ integrator = Leapfrog(initial_ϵ)
 
 # Define an HMC sampler with the following components
 #   - multinomial sampling scheme,
-#   - generalised No-U-Turn criteria, and
-#   - windowed adaption for step-size and diagonal mass matrix
+#   - generalised No-U-Turn criterion, and
+#   - windowed adaptation for step size and diagonal mass matrix
 kernel = HMCKernel(Trajectory{MultinomialTS}(integrator, GeneralisedNoUTurn()))
 adaptor = StanHMCAdaptor(MassMatrixAdaptor(metric), StepSizeAdaptor(0.8, integrator))
 
@@ -170,7 +170,7 @@ In the previous examples, we built the sampler by manually specifying the integr
     ```
 
 Moreover, there's some flexibility in how these samplers can be initialized.
-For example, a user can initialize a NUTS (HMC and HMCDA) sampler with their own metrics and integrators.
+For example, users can initialize NUTS, HMC, and HMCDA samplers with their own metrics and integrators.
 This can be done as follows:
 
 ```julia
@@ -182,7 +182,7 @@ metric = DiagEuclideanMetric(10)
 nuts = NUTS(δ; metric=metric)
 
 nuts = NUTS(δ; integrator=:leapfrog)         #integrator = Leapfrog(ϵ) (Default!)
-nuts = NUTS(δ; integrator=:jitteredleapfrog) #integrator = JitteredLeapfrog(ϵ, 0.1ϵ)
+nuts = NUTS(δ; integrator=:jitteredleapfrog) #integrator = JitteredLeapfrog(ϵ, 0.1)
 nuts = NUTS(δ; integrator=:temperedleapfrog) #integrator = TemperedLeapfrog(ϵ, 1.0)
 
 # Provide your own AbstractIntegrator
@@ -194,10 +194,10 @@ nuts = NUTS(δ; integrator=integrator)
 
 There is experimental support for running static HMC on the GPU using CUDA.
 To do so, the user needs to have [CUDA.jl](https://github.com/JuliaGPU/CUDA.jl) installed, ensure the logdensity of the `Hamiltonian` can be executed on the GPU and that the initial points are a `CuArray`.
-A small working example can be found at `test/cuda.jl`.
+A small working example can be found at `test/CUDA/cuda.jl`.
 
 ## Footnotes
 
-[^1]: The Euclidean metric is also known as the mass matrix in the physical perspective. See [Hamiltonian mass matrix](@ref hamiltonian-mm) for available metrics.
+[^1]: The Euclidean metric is also known as the mass matrix in the physical perspective. See [Hamiltonian mass matrix](@ref hamiltonian_mm) for available metrics.
 [^2]: About the leapfrog integration scheme: Suppose ${\bf x}$ and ${\bf v}$ are the position and velocity of an individual particle respectively; $i$ and $i+1$ are the indices for time values $t_i$ and $t_{i+1}$ respectively; $dt = t_{i+1} - t_i$ is the time step size (constant and regularly spaced intervals), and ${\bf a}$ is the acceleration induced on a particle by the forces of all other particles. Furthermore, suppose positions are defined at times $t_i, t_{i+1}, t_{i+2}, \dots $, spaced at constant intervals $dt$, the velocities are defined at halfway times in between, denoted by $t_{i-1/2}, t_{i+1/2}, t_{i+3/2}, \dots $, where $t_{i+1} - t_{i + 1/2} = t_{i + 1/2} - t_i = dt / 2$, and the accelerations ${\bf a}$ are defined only on integer times, just like the positions. Then the leapfrog integration scheme is given as: $x_{i} = x_{i-1} + v_{i-1/2} dt; \quad v_{i+1/2} = v_{i-1/2} + a_i dt$. For available integrators refer to [Integrator](@ref integrator).
 [^3]: On kernels: In the classical HMC approach, during the first step, new values for the momentum variables are randomly drawn from their Gaussian distribution, independently of the current values of the position variables. A Metropolis update is performed during the second step, using Hamiltonian dynamics to provide a new state. For available kernels refer to [Kernel](@ref kernel).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,7 +7,7 @@
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://turinglang.github.io/AdvancedHMC.jl/dev/)
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
-AdvancedHMC.jl provides a robust, modular, and efficient implementation of advanced Hamiltonian Monte Carlo(HMC) algorithms. AdvancedHMC.jl is part of [Turing.jl](https://github.com/TuringLang/Turing.jl), a probabilistic programming library in Julia.
+AdvancedHMC.jl provides a robust, modular, and efficient implementation of advanced Hamiltonian Monte Carlo (HMC) algorithms. AdvancedHMC.jl is part of [Turing.jl](https://github.com/TuringLang/Turing.jl), a probabilistic programming library in Julia.
 If you are interested in using AdvancedHMC.jl through a probabilistic programming language, please check it out!
 
 ## Citing AdvancedHMC.jl
@@ -20,7 +20,7 @@ with the following BibTeX entry:
 
 ```
 @inproceedings{xu2020advancedhmc,
-  title={AdvancedHMC. jl: A robust, modular and efficient implementation of advanced HMC algorithms},
+  title={AdvancedHMC.jl: A robust, modular and efficient implementation of advanced HMC algorithms},
   author={Xu, Kai and Ge, Hong and Tebbutt, Will and Tarek, Mohamed and Trapp, Martin and Ghahramani, Zoubin},
   booktitle={Symposium on Advances in Approximate Bayesian Inference},
   pages={1--10},
@@ -29,7 +29,7 @@ with the following BibTeX entry:
 }
 ```
 
-If you using AdvancedHMC.jl directly through Turing.jl, please consider citing the following publication:
+If you use AdvancedHMC.jl directly through Turing.jl, please consider citing the following publication:
 
 Hong Ge, Kai Xu, and Zoubin Ghahramani: "Turing: a language for flexible probabilistic inference.", *International Conference on Artificial Intelligence and Statistics*, 2018. ([abs](http://proceedings.mlr.press/v84/ge18b.html), [pdf](http://proceedings.mlr.press/v84/ge18b/ge18b.pdf))
 

--- a/ext/AdvancedHMCCUDAExt.jl
+++ b/ext/AdvancedHMCCUDAExt.jl
@@ -24,8 +24,8 @@ function AdvancedHMC.mh_accept_ratio(
     α = min.(one(T), exp.(Horiginal .- Hproposal))
     # NOTE: There is a chance that sharing the RNG over multiple
     #       chains for accepting / rejecting might couple
-    #       the chains. We need to revisit this more rigirously 
-    #       in the future. See discussions at 
+    #       the chains. We need to revisit this more rigorously
+    #       in the future. See discussions at
     #       https://github.com/TuringLang/AdvancedHMC.jl/pull/166#pullrequestreview-367216534
     r = CUDA.CuArray{T,1}(undef, length(Horiginal))
     CUDA.CURAND.rand!(r)

--- a/research/src/riemannian_hmc_utility.jl
+++ b/research/src/riemannian_hmc_utility.jl
@@ -4,7 +4,7 @@ using Random, LinearAlgebra, ReverseDiff, ForwardDiff, MCMCLogDensityProblems
 function gen_∂G∂θ_rev(Vfunc, x; f=identity)
     _Hfunc = MCMCLogDensityProblems.gen_hess(Vfunc, ReverseDiff.track.(x))
     Hfunc = x -> _Hfunc(x)[3]
-    # QUES What's the best output format of this function?
+    # QUESTION: What is the best output format for this function?
     return x -> ReverseDiff.jacobian(x -> f(Hfunc(x)), x) # default output shape [∂H∂x₁; ∂H∂x₂; ...]
 end
 
@@ -19,7 +19,7 @@ end
 function gen_∂G∂θ_fwd(Vfunc, x; f=identity)
     _Hfunc = gen_hess_fwd(Vfunc, x)
     Hfunc = x -> _Hfunc(x)[3]
-    # QUES What's the best output format of this function?
+    # QUESTION: What is the best output format for this function?
     cfg = ForwardDiff.JacobianConfig(Hfunc, x)
     d = length(x)
     out = zeros(eltype(x), d^2, d)

--- a/src/abstractmcmc.jl
+++ b/src/abstractmcmc.jl
@@ -213,7 +213,7 @@ end
     HMCProgressCallback
 
 A callback to be used with AbstractMCMC.jl's interface, replicating the
-logging behavior of the non-AbstractMCMC [`sample`](@ref).
+logging behavior of the non-AbstractMCMC `sample`.
 
 # Fields
 $(FIELDS)
@@ -361,7 +361,7 @@ function make_integrator(i::Symbol, ϵ::Real)
     if i === :leapfrog
         return Leapfrog(float_ϵ)
     elseif i === :jitteredleapfrog
-        return JitteredLeapfrog(float_ϵ, float_ϵ / 10)
+        return JitteredLeapfrog(float_ϵ, oftype(float_ϵ, 0.1))
     elseif i === :temperedleapfrog
         return TemperedLeapfrog(float_ϵ, oneunit(float_ϵ))
     else

--- a/src/adaptation/massmatrix.jl
+++ b/src/adaptation/massmatrix.jl
@@ -161,7 +161,7 @@ end
 
 Nutpie-style diagonal mass matrix estimator (using positions and gradients).
 
-Expected to converge faster and to a better mass matrix than [`WelfordVar`](@ref), for which it is a drop-in replacement.
+Expected to converge faster and to a better mass matrix than `WelfordVar`, for which it is a drop-in replacement.
 
 Can be initialized via `NutpieVar(sz)` where `sz` is either a `Tuple{Int}` or a `Tuple{Int,Int}`.
 
@@ -179,7 +179,7 @@ mutable struct NutpieVar{T<:AbstractFloat,E<:AbstractVecOrMat{T},V<:AbstractVecO
     n::Int
     "The minimal number of observations after which the estimate of the variances can be updated."
     n_min::Int
-    "The estimated variances - initialized to ones, updated after calling [`update!`](@ref) if `n > n_min`."
+    "The estimated variances - initialized to ones, updated after calling `update!` if `n > n_min`."
     var::V
     function NutpieVar(n::Int, n_min::Int, μ::E, M::E, δ::E, var::V) where {E,V}
         return new{eltype(E),E,V}(

--- a/src/adaptation/stan_adaptor.jl
+++ b/src/adaptation/stan_adaptor.jl
@@ -57,7 +57,7 @@ end
 
 ### Stan's windowed adaptation
 
-# Acknowledgement: this adaption settings is mimicing Stan's 3-phase adaptation.
+# These adaptation settings mimic Stan's three-phase adaptation.
 struct StanHMCAdaptor{M<:MassMatrixAdaptor,Tssa<:StepSizeAdaptor} <: AbstractAdaptor
     pc::M
     ssa::Tssa
@@ -147,7 +147,7 @@ function adapt!(
 
     # Ref: https://github.com/stan-dev/stan/blob/develop/src/stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp
     if is_in_window(tp)
-        # We accumlate stats from θ online and only trigger the update of M⁻¹ in the end of window.
+        # Accumulate statistics from θ online and update M⁻¹ only at the end of the window.
         is_update_M⁻¹ = is_window_end(tp)
         adapt!(tp.pc, z_or_theta, α, is_update_M⁻¹)
     end

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -207,7 +207,7 @@ end
 
 abstract type AbstractMomentumRefreshment end
 
-"Completly resample new momentum."
+"Completely resample new momentum."
 struct FullMomentumRefreshment <: AbstractMomentumRefreshment end
 
 function refresh(

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -4,8 +4,8 @@
 
 # TODO: The type `<:Tuple{Integer,Bool}` is introduced to address
 # https://github.com/TuringLang/Turing.jl/pull/941#issuecomment-549191813
-# We might want to simplify it to `Tuple{Int,Bool}` when we figured out
-# why the it behaves unexpected on Windows 32.
+# We might want to simplify it to `Tuple{Int,Bool}` once we understand
+# why it behaves unexpectedly on 32-bit Windows.
 
 """
 $(TYPEDEF)
@@ -13,10 +13,10 @@ $(TYPEDEF)
 Represents an integrator used to simulate the Hamiltonian system.
 
 # Implementation
-A `AbstractIntegrator` is expected to have the following implementations:
-- [`stat`](@ref)
-- [`nom_step_size`](@ref)
-- [`step_size`](@ref)
+An `AbstractIntegrator` is expected to implement:
+- `stat`
+- `nom_step_size`
+- `step_size`
 """
 abstract type AbstractIntegrator end
 
@@ -41,7 +41,7 @@ function step_size end
 """
     update_nom_step_size(i::AbstractIntegrator, ϵ) -> AbstractIntegrator
 
-Return a copy of the integrator `i` with the new nominal step size ([`nom_step_size`](@ref))
+Return a copy of the integrator `i` with the new nominal step size (`nom_step_size`)
 `ϵ`.
 """
 function update_nom_step_size end
@@ -89,13 +89,14 @@ Leapfrog integrator with randomly "jittered" step size `ϵ` for every trajectory
 $(TYPEDFIELDS)
 
 # Description
-This is the same as `LeapFrog`(@ref) but with a "jittered" step size. This means
+This is the same as [`Leapfrog`](@ref) but with a "jittered" step size. This means
 that at the beginning of each trajectory we sample a step size `ϵ` by adding or
 subtracting from the nominal/base step size `ϵ0` some random proportion of `ϵ0`,
-with the proportion specified by `jitter`, i.e. `ϵ = ϵ0 - jitter * ϵ0 * rand()`.
-p
+with the proportion specified by `jitter`, i.e.
+`ϵ = ϵ0 * (1 + jitter * (2 * rand() - 1))`.
+
 Jittering might help alleviate issues related to poor interactions with a fixed step size:
-- In regions with high "curvature" the current choice of step size might mean over-shoot
+- In regions with high "curvature" the current choice of step size might cause overshooting,
   leading to almost all steps being rejected. Randomly sampling the step size at the
   beginning of the trajectories can therefore increase the probability of escaping such
   high-curvature regions.

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -50,9 +50,9 @@ function Base.show(io::IO, ::MIME"text/plain", uem::UnitEuclideanMetric{T}) wher
 end
 
 struct DiagEuclideanMetric{T,A<:AbstractVecOrMat{T}} <: AbstractMetric
-    # Diagnal of the inverse of the mass matrix
+    # Diagonal of the inverse of the mass matrix
     M⁻¹::A
-    # Sqare root of the inverse of the mass matrix
+    # Square root of the inverse of the mass matrix
     sqrtM⁻¹::A
     # Pre-allocation for intermediate variables
     _temp::A
@@ -138,7 +138,7 @@ end
     WoodburyFactorization(U, Q, V)
 
 A factorization of a positive definite Woodbury matrix `W = A + B*D*Bᵀ`, with positive
-definite diagonal `A`, as returned by [`woodbury_factorize`](@ref).
+definite diagonal `A`, as returned by `woodbury_factorize`.
 
 The factors `U`, `Q`, and `V` are defined by the field descriptions below; together they
 allow sampling from `N(0, W⁻¹)` without forming `W`.

--- a/src/riemannian/hamiltonian.jl
+++ b/src/riemannian/hamiltonian.jl
@@ -224,7 +224,7 @@ end
 import AdvancedHMC: phasepoint, neg_energy, ∂H∂θ, ∂H∂r
 using LinearAlgebra: logabsdet, tr
 
-# QUES Do we want to change everything to position dependent by default?
+# QUESTION: Should everything be position-dependent by default?
 # Add θ to ∂H∂r for DenseRiemannianMetric
 function phasepoint(
     h::Hamiltonian{<:DenseRiemannianMetric},
@@ -249,7 +249,7 @@ function neg_energy(
     return -logZ - dot(r, h.metric._temp) / 2
 end
 
-# QUES L31 of hamiltonian.jl now reads a bit weird (semantically)
+# QUESTION: Does line 31 of `hamiltonian.jl` still have the intended meaning?
 function ∂H∂θ(
     h::Hamiltonian{<:DenseRiemannianMetric{T,<:IdentityMap}},
     θ::AbstractVecOrMat{T},

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -704,7 +704,7 @@ function transition(
             )
             treeleft, treeright = tree, tree′
         end
-        # Perform a MH step and increse depth if not terminated
+        # Perform an MH step and increase depth if not terminated
         if !isterminated(termination′)
             j = j + 1   # increment tree depth
             if mh_accept(rng, sampler, sampler′)
@@ -867,7 +867,7 @@ function mh_accept_ratio(
 ) where {T<:AbstractFloat}
     # NOTE: There is a chance that sharing the RNG over multiple
     #       chains for accepting / rejecting might couple
-    #       the chains. We need to revisit this more rigirously
+    #       the chains. We need to revisit this more rigorously
     #       in the future. See discussions at
     #       https://github.com/TuringLang/AdvancedHMC.jl/pull/166#pullrequestreview-367216534
     accept = if rng isa AbstractRNG

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -30,16 +30,16 @@ Return the axes of input `r`, where `r` can be `AbstractArrays`, `ComponentArray
 @inline __axes(r::AbstractVecOrMat) = axes(r)
 
 """
-`rand_coupled` produces coupled randomness given a vector of RNGs. For example,
-when a vector of RNGs is provided, `rand_coupled` performs a single `rand` call
-(rather than a `rand` call for each RNG) while keep all RNGs synchronised.
+`rand_coupled` produces coupled randomness given a vector of RNGs. It returns a
+value from the first RNG and advances every other RNG by calling `rand` with the
+same arguments, keeping the RNGs synchronised.
 This is important if we want to couple multiple Markov chains.
 """
 
 rand_coupled(rng::AbstractRNG, args...) = rand(rng, args...)
 
 function rand_coupled(rngs::AbstractVector{<:AbstractRNG}, args...)
-    # Dummpy calles to sync RNGs
+    # Dummy calls to synchronise the RNGs
     foreach(rngs[2:end]) do rng
         rand(rng, args...)
     end

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,4 +1,4 @@
-# TODO: add more target distributions and make them iteratable
+# TODO: add more target distributions and make them iterable
 # TODO: Integrate with https://github.com/xukai92/VecTargets.jl to achieve goal noted 
 #       above.
 

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -159,6 +159,13 @@ get_kernel_hyperparamsT(spl::NUTS, state) = typeof(state.κ.τ.termination_crite
     end
 end
 
+@testset "Symbolic integrator constructors" begin
+    @testset "$T" for T in (Float32, Float64)
+        integrator = AdvancedHMC.make_integrator(:jitteredleapfrog, T(0.01))
+        @test integrator.jitter === T(0.1)
+    end
+end
+
 @testset "Utils" begin
     @testset "initial_params" begin
         d = 2

--- a/test/integrator.jl
+++ b/test/integrator.jl
@@ -144,7 +144,7 @@ using Statistics: mean
             ps = ps[1_000:end]
             Hs = Hs[1_000:end]
 
-            # Check if all points located at a cirle centered at the origin
+            # Check if all points are located on a circle centered at the origin
             rs = sqrt.(qs .^ 2 + ps .^ 2)
             @test all(x -> abs(x - mean(rs)) < 2e-3, rs)
 

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -128,7 +128,7 @@ end
 
                     Random.seed!(1)
                     # For `MassMatrixAdaptor`, we use the pre-defined step size as the method cannot adapt the step size.
-                    # For other adapatation methods that are able to adapt the step size, we use `find_good_stepsize`.
+                    # For other adaptation methods that are able to adapt the step size, we use `find_good_stepsize`.
                     τ_used = if adaptorsym == :MassMatrixAdaptorOnly
                         τ
                     else


### PR DESCRIPTION
The symbolic `:jitteredleapfrog` constructor scaled its jitter proportion by the nominal step size, giving common small step sizes much less than the intended 10% jitter. Use a type-preserving `0.1` proportion and test both `Float32` and `Float64`.

Also correct invalid API examples, broken documentation references, stale citation metadata, and spelling errors.