### PR TITLE
Evaluate the next candidate step size in find_good_stepsize

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # AdvancedHMC Changelog
 
+## 0.8.8
+
+  - Fixes `find_good_stepsize` evaluating the current step size rather than the next candidate
+    in its crossing loop, which left the bisection interval above the acceptance-probability crossing.
+
 ## 0.8.7
 
   - Uses a fixed 10% jitter proportion for the `:jitteredleapfrog` convenience constructor.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedHMC"
 uuid = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
-version = "0.8.7"
+version = "0.8.8"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -797,9 +797,9 @@ function find_good_stepsize(
         # `ratio_too_high` being `false` means MH ratio too small
         #     - this means our step size is too large, thus we decrease
         ϵ′ = ratio_too_high ? d * ϵ : invd * ϵ
-        _, H′ = A(h, z, ϵ)
+        _, H′ = A(h, z, ϵ′)
         ΔH = H - H′
-        @debug "Crossing step" H′ ϵ α = min(1, exp(ΔH))
+        @debug "Crossing step" H′ ϵ′ α = min(1, exp(ΔH))
         # stop if there is no crossing; otherwise, continue to half or double stepsize.
         if xor(ratio_too_high, ΔH > log_a_cross)
             break

--- a/test/trajectory.jl
+++ b/test/trajectory.jl
@@ -324,3 +324,20 @@ end
         end
     end
 end
+
+@testset "find_good_stepsize" begin
+    h = Hamiltonian(
+        UnitEuclideanMetric(1),
+        get_ℓπ(Gaussian(zeros(1), ones(1))),
+        get_∇ℓπ(Gaussian(zeros(1), ones(1))),
+    )
+    θ = zeros(1)
+    ϵ = find_good_stepsize(MersenneTwister(1), h, θ)
+
+    r = AdvancedHMC.rand_momentum(MersenneTwister(1), h.metric, h.kinetic, θ)
+    z = AdvancedHMC.phasepoint(h, θ, r)
+    _, H′ = AdvancedHMC.A(h, z, ϵ)
+    α = min(1, exp(AdvancedHMC.energy(z) - H′))
+
+    @test 0.25 <= α <= 0.75
+end


### PR DESCRIPTION
The crossing loop in `find_good_stepsize` computed the next candidate `ϵ′` but evaluated the trajectory at the current `ϵ`, so on break `ϵ` was the step size that had already crossed and `ϵ′` sat one doubling past it. Bisection then searched an interval entirely above the acceptance crossing. Evaluating `A(h, z, ϵ′)` restores the invariant stated in the comment below the loop.

On the example in #523 the returned step size goes from 6.4, acceptance 0.0196, to 4.8, acceptance 0.288, inside the 0.25 to 0.75 band set by `log_a_min` and `log_a_max`. The test added to `test/trajectory.jl` evaluates 0.0196 and fails without the change. Algorithm 4 of Hoffman and Gelman, implemented separately, also stops at 6.4 from the same starting point, since the published heuristic returns the crossed step size and has no bisection stage. The band is this package's own target and only reachable if the crossing loop leaves a bracket containing the crossing.

`test/abstractmcmc.jl:89` fails here, but it is seed-dependent on `main` as well. The gdemo post-warmup mean of `s` over seeds 0, 1, 2, 3, 42 is 1.981, 2.241, 2.845, 656003.8, 3.298 on `main` against 2.066, 3.025, Inf, 2.426, 452.4 with this change, two of five passing either way, and `max_s` reaches Inf on both. I have left it untouched pending your answer on the issue.

Fixes #523.
